### PR TITLE
Update infrared.md to mention ESP8266 quirks

### DIFF
--- a/docs/interfaces/infrared.md
+++ b/docs/interfaces/infrared.md
@@ -13,6 +13,9 @@ A dedicated infrared receiver module is required.
 (KY-022 or TSOP38238 are confirmed to work and inexpensive)
 
 The default sensor pin is GPIO4. It can be changed in the Wled settings.
+On ESP8266, it's recommended to use pins GPIO1, GPIO2, GPIO3 for the LED output if you want to use IR.
+(These pins use [DMA/UART](https://github.com/Makuna/NeoPixelBus/wiki/ESP8266-NeoMethods) control, 
+other pins will use bit-banging, which results in unreliable IR data decoding.) 
 
 ### Supported IR remotes
 To use IR remote go to `Settings`, `Sync Interfaces` and change the value for `Infrared receiver type` according to the IR remote type of the following list:


### PR DESCRIPTION
Short chains (8 WS2812b's) work fine with bit-banging + IR, longer ones (20+) make IR reception unreliable. It's easy to reproduce if you connect an IR receiver to a ESP8266 devkit and check the console output, it doesn't need a LED chain to reproduce. This is not an issue on ESP32 (as far as I could tell, maybe the processing speed is just fast enough there). Unreliable IR reception is super-annoying to debug and moving the chain from GPIO4 to GPIO1,2, or 3 was a quick fix I didn't expect, and which was non-trivial to figure out. Older Wled versions throw a warning when compiling with bit-banging pins, that's when it clicked.