### PR TITLE
Update getting-started to mention recommended ESP8266 pins

### DIFF
--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -38,7 +38,7 @@ Go to the IP `4.3.2.1` in your browser. You should also be able to use the embed
 ### Default GPIO Usage
 
 !!! info "These are only defaults"
-    All pins can be changed in the Hardware section of LED settings. Please note that these are GPIO numbers, please consult a pinout for your board to find the labeled pin (e.g `D4` = `GPIO2` on most ESP8266 boards). When using an ESP8266 board, it's recommended to use pins `GPIO1`, `GPIO2`, or `GPIO3` for LED Data; using other pins will require bit-banging and may cause issues elsewhere (such as with IR decoding).
+    All pins can be changed in the Hardware section of LED settings. Please note that these are GPIO numbers, please consult a pinout for your board to find the labeled pin (e.g `D4` = `GPIO2` on most ESP8266 boards). When using an ESP8266 board, it's recommended to use pins `GPIO1`, `GPIO2`, or `GPIO3` for LED Data; using other pins will require _bit-bangging_ and may cause slow performance and/or issues elsewhere (such as with IR decoding).
 
 | Device | GPIO | Notes |
 |---|---|---|

--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -38,7 +38,7 @@ Go to the IP `4.3.2.1` in your browser. You should also be able to use the embed
 ### Default GPIO Usage
 
 !!! info "These are only defaults"
-    All pins can be changed in the Hardware section of LED settings. Please note that these are GPIO numbers, please consult a pinout for your board to find the labeled pin (e.g D4 = GPIO2 on most ESP8266 boards)
+    All pins can be changed in the Hardware section of LED settings. Please note that these are GPIO numbers, please consult a pinout for your board to find the labeled pin (e.g `D4` = `GPIO2` on most ESP8266 boards). When using an ESP8266 board, it's recommended to use pins `GPIO1`, `GPIO2`, or `GPIO3` for LED Data; using other pins will require bit-banging and may cause issues elsewhere (such as with IR decoding).
 
 | Device | GPIO | Notes |
 |---|---|---|


### PR DESCRIPTION
As mentioned in https://github.com/Makuna/NeoPixelBus/wiki/ESP8266-NeoMethods only pins GPIO1,2,3 on ESP8266 support non-bit-banging for LED data. Using bit-banging can cause hard-to-troubleshoot issues, such as IR decoding not being consistent.