### PR TITLE
Add description to offset to the segments page

### DIFF
--- a/docs/features/segments.md
+++ b/docs/features/segments.md
@@ -62,3 +62,9 @@ Grouping and Spacing can be combined to create many different custom LED layouts
 |Grouping 2<br /> Spacing 1| ![](https://github.com/twlare/WLEDDocs/raw/master/G2S1A.png) |
 |Grouping 2<br /> Spacing 1| ![](https://github.com/twlare/WLEDDocs/raw/master/G2S1Cycle.gif) |
 
+## Offset in a segment
+By default effects start in the first LED in the segment and finish in the last one. If the offset parameter in a segment is used, the effect start will be moved by the number of positions entered, it will continue to the last LED and then finish with the initial positions that were skipped.
+
+For instance, if you have a strip of 12 LEDs (and we number the positions 0-11, like above) a skip value of 5 will make the effect start in position 5, continue to position 11 and then finish with positions 0 through 4.
+
+A negative offset value is allowed and represents an offset starting from the last position in the segment. In our previous example, an offset of -2 will start the effect in position 10.

--- a/docs/features/segments.md
+++ b/docs/features/segments.md
@@ -65,6 +65,16 @@ Grouping and Spacing can be combined to create many different custom LED layouts
 ## Offset in a segment
 By default effects start in the first LED in the segment and finish in the last one. If the offset parameter in a segment is used, the effect start will be moved by the number of positions entered, it will continue to the last LED and then finish with the initial positions that were skipped.
 
-For instance, if you have a strip of 12 LEDs (and we number the positions 0-11, like above) a skip value of 5 will make the effect start in position 5, continue to position 11 and then finish with positions 0 through 4.
+For instance, let's assume assume a strip of 12 LEDs with the positions numbered as follows (like the examples above):
 
-A negative offset value is allowed and represents an offset starting from the last position in the segment. In our previous example, an offset of -2 will start the effect in position 10.
+![](https://github.com/twlare/WLEDDocs/raw/master/LEDS12.png)
+
+A skip value of 5 will make the effect start in the physical position 5, continue to position 11 and then finish with positions 0 through 4, like this:
+
+![](https://github.com/twlare/WLEDDocs/raw/master/LED7to6.png)
+
+A negative offset value is allowed and represents an offset starting from the last position in the segment. In our previous example, an offset of -2 will start the effect in position 10, like this:
+
+![](https://github.com/twlare/WLEDDocs/raw/master/LED2to1.png)
+
+The offset values is prioritized over grouping and/or spacing. For For example, if the offset is 2, grouping 4 and spacing 1, the first group of 4 LEDs will start at the physical position number 2.

--- a/docs/features/segments.md
+++ b/docs/features/segments.md
@@ -77,4 +77,4 @@ A negative offset value is allowed and represents an offset starting from the la
 
 ![](https://github.com/twlare/WLEDDocs/raw/master/LED2to1.png)
 
-The offset values is prioritized over grouping and/or spacing. For For example, if the offset is 2, grouping 4 and spacing 1, the first group of 4 LEDs will start at the physical position number 2.
+The offset values is prioritized over grouping and/or spacing. For example, if the offset is 2, grouping 4 and spacing 1, the first group of 4 LEDs will start at the physical position number 2.


### PR DESCRIPTION
I noticed that there was no documentation to the new offset parameter in segments so I wrote something based on discussion I read in issues in the main repo.

Please review and propose improvements. I tried to keep it simple, but I can thing of two more things that I could add, but I need extra information:
- How does the offset value interact with grouping and spacing?
- Is it worth adding a visual to the explanation, like in the grouping/spacing section?

Thanks for all your work. Happy to contribute!