### PR TITLE
Give a hint on why on should "optionally connect a pushbutton"

### DIFF
--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -12,7 +12,7 @@ hide:
 
 ### Quick start guide
 
-**1.** Connect a  WS2812B-compatible RGB(W) led strip to `GPIO2`. On most ESP8266 based development boards this pin is labeled `D4`, on ESP32 based boards use `IO16` or `G16` or `16`. _If this wire cannot be kept short, use a [level shifter/translator](/basics/compatible-hardware#levelshifters)._ Optionally connect a normally open pushbutton to `GPIO0` (NodeMCU/Wemos pin `D3`, on ESP32 use `IO17`) and ground.
+**1.** Connect a  WS2812B-compatible RGB(W) led strip to `GPIO2`. On most ESP8266 based development boards this pin is labeled `D4`, on ESP32 based boards use `IO16` or `G16` or `16`. _If this wire cannot be kept short, use a [level shifter/translator](/basics/compatible-hardware#levelshifters)._ Optionally connect a normally open pushbutton to `GPIO0` (NodeMCU/Wemos pin `D3`, on ESP32 use `IO17`) and ground for [configurable actions](/features/macros).
 **Note:** Board pin naming varies depending on the manufacturer. Please use the board pinout from the _specific_ board you purchased and use the GPIO PINS to reference this guide. _Make sure to connect ESP and LED-strip grounds together!_
 
 ![Connection schematics](https://i.ibb.co/gtkLKgp/image.png)


### PR DESCRIPTION
I was reading the getting started documentation at https://kno.wled.ge/basics/getting-started/ and read "Optionally connect a normally open pushbutton to GPIO0 (NodeMCU/Wemos pin D3, on ESP32 use IO17) and ground.", but could not find any more information on the button's purpose.

The documentation should give enough information to make an educated decision on whether to mount this optional button or not. (I asked in Discord and heard that it can be used to control effects etc., so that sounds quite useful.)

See https://github.com/Aircoookie/WLED/issues/2451