### PR TITLE
Update compiling-wled.md

### DIFF
--- a/docs/basics/compiling-wled.md
+++ b/docs/basics/compiling-wled.md
@@ -91,3 +91,4 @@ ESP-07s (External Antenna):
 ESP32:
 
 - Arduino Core v1.0.4
+Note : NpbWrapper is no longer being used in 013.0.b7  


### PR DESCRIPTION
Note : NpbWrapper is no longer being used in 013.0.b7