### PR TITLE
Link corrected

### DIFF
--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -20,7 +20,7 @@ hide:
 If using an ESP8266 and LEDs that have clock and data, use GPIO1 (TxD) for clock and GPIO2 (D4) for data.
 
 For safe operation it is recommended to dimension your wiring correctly and to integrate fuses.  
-To help you out, you may refer to this ![LED power, wiring and fuse calculator](https://wled-calculator.github.io/).
+To help you out, you may refer to this [LED power, wiring and fuse calculator](https://wled-calculator.github.io/).
 
 For analog use, the IRLZ44N or STP55NF06L is a good MOSFET to use. Partial, example circuit...
 


### PR DESCRIPTION
The link to another page was entered as an image link. Corrected.