### PR TITLE
Fix &NF= parameter being displayed on two lines in documentation

### DIFF
--- a/docs/interfaces/http-api.md
+++ b/docs/interfaces/http-api.md
@@ -41,8 +41,7 @@ Add one or multiple of the following parameters after the base URL/IP to change 
 &NL= | 0 to 255 | Nightlight active and duration in minutes | 0.3
 &ND | none | Toggles nightlight on but uses default duration | 0.6.3
 &NT= | 0 to 255 | Nightlight target brightness | 0.5.0
-&NF= | 0 to 2 | Fade Nightlight, 1 = fade brightness only,
-2 = additionaly fade color from primary to secondary color | 0.5.0
+&NF= | 0 to 2 | Fade Nightlight, 1 = fade brightness only, 2 = additionaly fade color from primary to secondary color | 0.5.0
 
 ## Advanced
 


### PR DESCRIPTION
`&NF=` parameter is currently displayed on 2 lines. Fix by removing extra new line

Before:
![image](https://user-images.githubusercontent.com/64211882/187113910-c52a84ba-663c-4ae5-97c6-21dcc3605556.png)

After: 
![image](https://user-images.githubusercontent.com/64211882/187113668-4b993668-4ec8-45da-a26b-b32215a668e8.png)
