### PR TITLE
Added information on how to iterate through presets

### DIFF
--- a/docs/interfaces/json-api.md
+++ b/docs/interfaces/json-api.md
@@ -129,7 +129,7 @@ on | bool | On/Off state of the light
 bri | 0 to 255 | Brightness of the light. If _on_ is `false`, contains last brightness when light was on (aka brightness when _on_ is set to true. Setting _bri_ to 0 is supported but it is recommended to use the range 1-255 and use `on: false` to turn off. The state response will never havethe value `0` for _bri_.
 transition | 0 to 255 | Duration of the crossfade between different colors/brightness levels. One unit is 100ms, so a value of `4` results in atransition of 400ms.
 tt | 0 to 255 | Similar to transition, but applies to just the current API call. Not included in state response.
-ps | -1 to 65535 | ID of currently set preset.
+ps | -1 to 65535 | ID of currently set preset. "1~17~" can be used to iterate through presets 1-17.
 ~~pss~~ | 0 to 65535 | Bitwise indication of preset slots (0 - vacant, 1 - written). Always 0 in 0.11. Not changable. _Removed as of v0.11.1_
 psave | 1 to 16 (250 in 0.11) | Save current light config to specified preset slot. Not included in state response.
 pl | -1 to 0 | ID of currently set playlist. For now, this sets the preset cycle feature, `-1` is off and `0` is on.


### PR DESCRIPTION
Added, "1~17~" can be used to iterate through presets 1-17 under PS section.
Thought this could be helpful. This is my first pull request so I hope I did this right. :)