### PR TITLE
Clarified use of internal pull up resistors

### DIFF
--- a/docs/features/macros.md
+++ b/docs/features/macros.md
@@ -23,7 +23,7 @@ You can specify up to 16 macros. (up to 250 in WLED 0.11 since the Macro functio
 
 Examples of how to use API-calls and define macros can be found in [this issue](https://github.com/Aircoookie/WLED/issues/801#issuecomment-635600255) and [in this one](https://github.com/Aircoookie/WLED/issues/199#issuecomment-520143239).
 
-The simplest macro example is getting a button to do your bidding.  The default pin to which a button can be connected is GPIO 0 (D3 on NodeMCU, D1 Mini and others).  This pin is ideally pulled high to 3.3V with a 10k resistor and the configured macro executes when the pin is pulled low (grounded). The desired macro is entered on the Time/Macros configuration page and then assigned to a short, long or double press. Like this:
+The simplest macro example is getting a button to do your bidding.  The default pin to which a button can be connected is GPIO 0 (D3 on NodeMCU, D1 Mini and others).  Even though WLED uses the internal pull up resistors on input pins, this pin is ideally externally pulled high to 3.3V with a 10k resistor. The configured macro executes when the pin is pulled low (grounded). The desired macro is entered on the Time/Macros configuration page and then assigned to a short, long or double press. Like this:
 ![how to wire a button to D3 and set up a macro](https://user-images.githubusercontent.com/40203361/64235553-e3c41300-cef8-11e9-833f-c5062aaba124.jpg)
 
 The "T=2" macro toggles power to the LEDs (in this case long press).


### PR DESCRIPTION
In some cases, like on a board I designed, the internal pull up can mess up the function of the external circuit driving the input pin.  This commit mentions the use of the internal pull up resistors, so designers can adjust their PCB designs accordingly.