### PR TITLE
Added new segment DMX modes

### DIFF
--- a/docs/interfaces/e1.31-dmx.md
+++ b/docs/interfaces/e1.31-dmx.md
@@ -17,6 +17,9 @@ WLED supports the E1.31 (sACN) realtime light protocol.
     **As of WLED v0.11.0, DDP is alternatively supported.** Using DDP, the Multi RGB DMX mode is always used regardless of the DMX mode setting (as it is no DMX)
     You will need to switch to DDP mode in Sync settings and reboot once.  
 
+!!! info "Version Info"
+    **As > WLED 0.14.0-b1, DMX Effect mode channel mapping changed.** This is a breaking change in E131 sync behavior. Existing DMX setups using WLED Effect mode are likely to break. Solution: Adopt external DMX channel mappings according to the new Effect mode channel layout.  
+
 ### Features
 
 * 170 LEDs (510 DMX channels) are supported per universe.

--- a/docs/interfaces/e1.31-dmx.md
+++ b/docs/interfaces/e1.31-dmx.md
@@ -100,7 +100,7 @@ Same as `Effect` with additional whites = 18 channels.
 
 Same as `Effect` with 15 channels per segment; expect `channel 1 = "Segment Dimmer"`.
 
-All effect segment modes introduce an additional `DMX segment spacing`. If spacing `s = 0` subsequent DMX addresses for all segments are created. When `s > 0` a gap of `s` DMX addresses between segments is used. To calculate segement DMX fixture addresses:
+All effect segment modes introduce an additional `DMX segment spacing`. If spacing `s = 0` subsequent DMX addresses for all segments are created. When `s > 0` a gap of `s` DMX addresses between segments is used. To calculate segment DMX fixture addresses:
 
     Segment DMX Address (i) = DMXAddress + i * (dmxEffectChannels + s)
 

--- a/docs/interfaces/e1.31-dmx.md
+++ b/docs/interfaces/e1.31-dmx.md
@@ -56,7 +56,7 @@ All LEDs are set to the same color. 4 Channels: Master Dimmer, Red, Green, Blue
 
 #### 3: Effect
 
-Not a realtime mode. Allows setting WLED effect properties over E1.31 with 11 or 13 channels.
+Not a realtime mode & only support 1 universe. Allows setting WLED effect properties over E1.31 with 15 channels.
 
 | Channel | Property |
 | --- | --- |
@@ -65,21 +65,69 @@ Not a realtime mode. Allows setting WLED effect properties over E1.31 with 11 or
 3 | Effect speed
 4 | Effect intensity
 5 | Effect palette ID
-6 | Red Primary
-7 | Green Primary
-8 | Blue Primary
-9 | Red Secondary
-10 | Green Secondary
-11 | Blue Secondary
-12 | White Primary (channel optional)
-13 | White Secondary (channel optional)
+6 | Effect option
+7 | Red Primary
+8 | Green Primary
+9 | Blue Primary
+10 | Red Secondary
+11 | Green Secondary
+12 | Blue Secondary
+13 | Red Tertiary
+14 | Green Tertiary
+15 | Blue Tertiary
 
-#### 4: Multiple RGB
+The `effect option` channel is divided into 4 macro parts to control _mirror_ and _reverse_ states as follows:
+
+| value    | mirror   | reverse | |
+|----------|----------|---------|-|
+| 0..63    | false    | false   | **none** |
+| 64..127  | false    | true    | **reverse** |
+| 128..191 | true     | false   | **mirror** |
+| 192..255 | true     | true    | **mirror & reverse** |
+
+#### 4: Effect + White
+
+Same as `Effect` with additional whites = 18 channels.
+
+| Channel | Property |
+| --- | --- |
+.. | ..
+16 | White Primary
+17 | White Secondary
+18 | White Tertiary
+
+#### 5: Effect Segment
+
+Same as `Effect` with 15 channels per segment; expect `channel 1 = "Segment Dimmer"`.
+
+All effect segment modes introduce an additional `DMX segment spacing`. If spacing `s = 0` subsequent DMX addresses for all segments are created. When `s > 0` a gap of `s` DMX addresses between segments is used. To calculate segement DMX fixture addresses:
+
+    Segment DMX Address (i) = DMXAddress + i * (dmxEffectChannels + s)
+
+Where `DMXAddress` = start address as configured in UI, `dmxEffectChannels` = 15|18 depending on selected effect segment mode, `s` = address gap as configured in UI and `i` is the index id of each segment as existing.
+
+Note: 1 DMX universe = max 512 DMX addresses. So max number of segments depends on `DMXAddress`, selected segment mode and configured `DMX segment spacing`. To calculate how many segments can be controlled via DMX:
+
+    Max segments = floor[ (512 - DMXAddress) / (dmxEffectChannels + s) ]
+
+#### 6: Effect Segment + White
+
+Same as `Effect Segment` including whites, so it uses 18 DMX channels per segment.
+
+#### 7: Multiple RGB
 
 3 Channels per LED in sequence. LED 0 Red, LED 0 Green, LED 0 Blue, LED 1 Red, ...
 Default mode, equivalent to pre-0.9.1 E1.31. This is the mode you want to use for xLights and LedFx.
 
-#### 5: Multiple DRGB
+#### 8: Dimmer + Multi RGB
 
-Like Multiple RGB, but the first channel is a brightness control.
+Like `Multiple RGB`, but the first channel is a brightness control.
 Master Dimmer, LED 0 Red, LED 0 Green, ...
+
+#### 9: Multiple RGBW
+
+Like `Multiple RGB` + additional white channels.
+
+#### 10: Preset
+
+Trigger presets and control brightness. 2 Channels: Brightness, Preset ID

--- a/docs/interfaces/e1.31-dmx.md
+++ b/docs/interfaces/e1.31-dmx.md
@@ -42,19 +42,19 @@ If you want to manually add devices, use more than 170 LEDs with LedFx, you need
 
 Select the mode you want to use in Sync settings.
 
-#### 0: Disabled
+#### Disabled
 
 Incoming E1.31 packets will be ignored.
 
-#### 1: Single RGB
+#### Single RGB
 
 All LEDs are set to the same color. 3 Channels: Red, Green, Blue
 
-#### 2: Single DRGB
+#### Single DRGB
 
 All LEDs are set to the same color. 4 Channels: Master Dimmer, Red, Green, Blue
 
-#### 3: Effect
+#### Effect
 
 Not a realtime mode & only support 1 universe. Allows setting WLED effect properties over E1.31 with 15 channels.
 
@@ -76,7 +76,7 @@ Not a realtime mode & only support 1 universe. Allows setting WLED effect proper
 14 | Green Tertiary
 15 | Blue Tertiary
 
-The `effect option` channel is divided into 4 macro parts to control _mirror_ and _reverse_ states as follows:
+The `effect option` channel is divided into 4 macro parts to control _mirror_ and _reverse_ states:
 
 | value    | mirror   | reverse | |
 |----------|----------|---------|-|
@@ -85,7 +85,7 @@ The `effect option` channel is divided into 4 macro parts to control _mirror_ an
 | 128..191 | true     | false   | **mirror** |
 | 192..255 | true     | true    | **mirror & reverse** |
 
-#### 4: Effect + White
+#### Effect + White
 
 Same as `Effect` with additional whites = 18 channels.
 
@@ -96,7 +96,7 @@ Same as `Effect` with additional whites = 18 channels.
 17 | White Secondary
 18 | White Tertiary
 
-#### 5: Effect Segment
+#### Effect Segment
 
 Same as `Effect` with 15 channels per segment; expect `channel 1 = "Segment Dimmer"`.
 
@@ -106,28 +106,28 @@ All effect segment modes introduce an additional `DMX segment spacing`. If spaci
 
 Where `DMXAddress` = start address as configured in UI, `dmxEffectChannels` = 15|18 depending on selected effect segment mode, `s` = address gap as configured in UI and `i` is the index id of each segment as existing.
 
-Note: 1 DMX universe = max 512 DMX addresses. So max number of segments depends on `DMXAddress`, selected segment mode and configured `DMX segment spacing`. To calculate how many segments can be controlled via DMX:
+Note: 1 DMX universe = max 512 DMX addresses. So max number of segments depends on start address, selected segment mode and configured DMX segment spacing. To calculate how many segments can be controlled:
 
     Max segments = floor[ (512 - DMXAddress) / (dmxEffectChannels + s) ]
 
-#### 6: Effect Segment + White
+#### Effect Segment + White
 
 Same as `Effect Segment` including whites, so it uses 18 DMX channels per segment.
 
-#### 7: Multiple RGB
+#### Multiple RGB
 
 3 Channels per LED in sequence. LED 0 Red, LED 0 Green, LED 0 Blue, LED 1 Red, ...
 Default mode, equivalent to pre-0.9.1 E1.31. This is the mode you want to use for xLights and LedFx.
 
-#### 8: Dimmer + Multi RGB
+#### Multiple RGBW
+
+Like `Multiple RGB` + additional white channels.
+
+#### Dimmer + Multi RGB
 
 Like `Multiple RGB`, but the first channel is a brightness control.
 Master Dimmer, LED 0 Red, LED 0 Green, ...
 
-#### 9: Multiple RGBW
-
-Like `Multiple RGB` + additional white channels.
-
-#### 10: Preset
+#### Preset
 
 Trigger presets and control brightness. 2 Channels: Brightness, Preset ID


### PR DESCRIPTION
Adds descriptions for
- new DMX preset mode
- new DMX effect segment modes 
- missing docs of multiple RGBW mode

Coming from: https://github.com/Aircoookie/WLED/pull/2891

Note: These changes describe WLED versions > **0.14.0-b1** - as the PR got merged.

For **b2** or **0.14.0** release: This is a breaking change in E131 sync behavior. It shall be mentioned in release notes. Existing user DMX setups using `Effect` mode may break. Solution: External DMX channel mappings must adopt accordingly.