### PR TITLE
Missing parameters "on" and "n"

### DIFF
--- a/docs/interfaces/json-api.md
+++ b/docs/interfaces/json-api.md
@@ -289,6 +289,8 @@ Sample playlist API call:
     "repeat": 10,
     "end": 21
   }
+  "on": true,
+  "n": "MyPlaylist"
 }
 ```
 


### PR DESCRIPTION
Compared to the actual file (presets.json) it appears "on" and "n" are missing from the documentation.