### PR TITLE
Adds details about WLED Native

### DIFF
--- a/docs/about/contributors.md
+++ b/docs/about/contributors.md
@@ -12,9 +12,10 @@ This page is to honor the work of all the people who helped to make WLED what it
 Everyone you see on the Contributors page and:  
 8bitbrett made the WiFi auto connect QR code with the Aircoookie/WLED logo!  
 adamo made the animated Discord server logo!  
-[@blazoncek](https://github.com/blazoncek) makes countless new features and improvements to many parts of WLED!
+[@blazoncek](https://github.com/blazoncek) makes countless new features and improvements to many parts of WLED!  
 [@debsahu](https://github.com/debsahu) provided the HomeAssistant autodiscovery and a lot of help with PIO!  
 [@frenck](https://github.com/frenck) made an amazing, stable and feature-packed native integration with HomeAssistant!  
+[@Moustachauve](https://github.com/Moustachauve)  added palette visualisation and developped the WLED Native app for Android and iOS!  
 [@photocromax](https://github.com/photocromax) is helping bringing the Live visualization feature to life and added GIF previews to the doc!  
 [@raymiec](https://github.com/raymiec)  is currently working on creating the best clients for Android and iOS!  
 [@StormPie](https://github.com/stormpie), the creator of the awesome mobile UI!  

--- a/docs/basics/compatible-software.md
+++ b/docs/basics/compatible-software.md
@@ -24,6 +24,7 @@ Controllers use the WLED API to change the current light settings.
 | [OctoPrint-WLED](https://plugins.octoprint.org/plugins/wled) | Connect your [OctoPrint](https://octoprint.org) install to your WLED install using this plugin to show things like printer status, progress and more! |
 [openHAB](https://community.openhab.org/t/wled-a-binding-for-controlling-led-strips-and-strings-from-an-opensource-esp8266-project/87286) | Another more professional feature rich home automation system. WLED integration made easy. [Link 2](https://community.openhab.org/t/solved-wled-please-make-this-work-in-openhab/82783) |
 [WLED-GUI](https://github.com/WoodyLetsCode/WLED-GUI) | This is a cross-platform desktop app for WLED. You can use it on Windows, Linux and Mac.
+[WLED Native for Android](https://github.com/Moustachauve/WLED-Native-Android)<br /> [WLED Native for iOS](https://github.com/Moustachauve/WLED-Native-iOS/) | An alternative version of the WLED app with a similar user interface to the official one that looks close to the native OS style guidelines and has a few more features added on top of it.
 [wledQuickControl](https://github.com/satrik/wledQuickControl) | macOS 11.0+ Menu Bar app for controlling power and brightness.
 
 ## Sources

--- a/docs/basics/faq.md
+++ b/docs/basics/faq.md
@@ -275,6 +275,14 @@ Segments are non-persistant by default. If you want to load your preset at every
 
 This will be improved in a future release, so that you will be able to save multiple segment configurations!
 
+### What is the difference between the WLED app and the WLED Native app?
+
+The WLED app is the official app developped by the same people that brought you WLED. WLED Native is an initiative by community member [Moustachauve](https://github.com/Moustachauve) to bring an interface that is closer to the native operating system look of your device and some new features.
+
+WLED Native has a few more features available, like a tablet interface for Android and can keep track of changes to the device IP address better.
+
+While WLED Native is not the official app, it is officially endorsed and trusted by the WLED maintainers.
+
 ### May I sell a product running WLED?
 
 WLED is licensed under the MIT license, thus you are free to use it in any way you wish as long as you retain the copyright notice and accept that I am not to be held liable for anything regarding your use of the software. For product pages, a link to the WLED GitHub repository would be hugely appreciated !

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,9 @@ A fast and feature-rich implementation of an ESP8266/ESP32 webserver to control 
 ## 💡 Supported light control interfaces
 
 - [WLED app](https://github.com/Aircoookie/WLED-App) for [Android](https://play.google.com/store/apps/details?id=com.aircoookie.WLED) and [iOS](https://apps.apple.com/us/app/wled/id1475695033)
+  - Alternatively, WLED Native app made by community member [Moustachauve](https://github.com/Moustachauve)
+    - For [Android](https://play.google.com/store/apps/details?id=ca.cgagnier.wlednativeandroid) [[Source]((https://github.com/Moustachauve/WLED-Native-Android))]
+    - For [iOS](https://apps.apple.com/us/app/wled-native/id6446207239) [[Source]((https://github.com/Moustachauve/WLED-Native-iOS/))]
 - [JSON](/interfaces/json-api) and [HTTP request](/interfaces/http-api) APIs  
 - [MQTT](/interfaces/mqtt)  
 - [Blynk IoT](/interfaces/blynk)  


### PR DESCRIPTION
- Adds details about WLED Native on the index page.
- Marks WLED Native as officially endorsed by the WLED team. 
- Adds WLED Native to the list of compatible software. 
- Adds Moustachauve to the list of WLED Contributors.

This should help with people who are afraid to use WLED Native over the official WLED app because they do not want to install unknown software. 
I feel like my descriptions might come out a little bit pretentious and that is not my intention. I'm not really good at writing and I did not have great inspiration. Feel free to edit or suggest changes to improve my writing.