### PR TITLE
Added info for analog buttons & microphones

### DIFF
--- a/docs/advanced/audio-reactive.md
+++ b/docs/advanced/audio-reactive.md
@@ -23,6 +23,9 @@ Three microphone types are supported:
 Examples are MAX4466 (not really good) and MAX9814 (slightly better). These microphones are easy to use: you just have to connect 3.3V, GND and the analog output from the microphone to an ADC input (Analog-to-Digital Converter) of ESP32. However, the big disadvantage is the quality: both from the microphones themselves and from the ADCs integrated into microcontrollers, which are actually not well suited for audio processing and highly influenced by the power supply noise.
 ![Example analog microphone](../assets/images/content/example_analog_mic.jpg)
 
+!!! info "Analog microphones and analog buttons rule out each other"
+    WLED can use analog microphones or [analog buttons](features/macros/#analog-button) but not both at the same time!
+
 #### 2. I2S digital microphones
 
 Examples are INMP441 and ICS-43434/ICS-43432. These have an integrated ADC and already output a digital signal. The advantage is the best possible quality. The disadvantage is higher complexity (you need several PINs for a digital signal). For proper trouble-free operation keep wires between the microphone and ESP32 as short as possible and solder them properly.


### PR DESCRIPTION
Added missing info about analog buttons when using analog microphones in audio reactive mode:

https://wled.discourse.group/t/analog-microphone-analog-potentiometer/9531