### PR TITLE
Added basic DDP docs and JSON API example implementaion

### DIFF
--- a/docs/interfaces/ddp.md
+++ b/docs/interfaces/ddp.md
@@ -1,0 +1,22 @@
+---
+title: DDP protocol
+hide:
+  # - navigation
+  # - toc
+---
+
+# Distributed Display Protocol
+
+DDP is a protocol designed by 3waylabs outlined [here on their website](http://www.3waylabs.com/ddp/).
+
+WLED listens for DDP packets on port 4048, as outlined by the protocol.
+Check the [DDP documentation](http://www.3waylabs.com/ddp/) for more info about packet structure.
+
+**Notice*
+WLED does not read the optional timecodes in DDP packet headers. 
+If you are implementing the protocol to send packets to WLED, do not bother implementing it
+
+## Example implementations
+
+ - [ddp-rs](https://github.com/coral/ddp-rs) A Rust library for sending (and even receiving) DDP packets.
+ - [LedFX/devices/ddp.py](https://github.com/LedFx/LedFx/blob/main/ledfx/devices/ddp.py) LedFX's implementation for sending DDP packets to WLED

--- a/docs/interfaces/ddp.md
+++ b/docs/interfaces/ddp.md
@@ -7,6 +7,8 @@ hide:
 
 # Distributed Display Protocol
 
+NOT TO BE CONFUSED WITH UDP.
+
 DDP is a protocol designed by 3waylabs outlined [here on their website](http://www.3waylabs.com/ddp/).
 
 WLED listens for DDP packets on port 4048, as outlined by the protocol.

--- a/docs/interfaces/json-api.md
+++ b/docs/interfaces/json-api.md
@@ -1,8 +1,8 @@
 ---
 title: JSON API
 hide:
-# - navigation
-# - toc
+  # - navigation
+  # - toc
 ---
 
 WLED versions since 0.8.4 implement a powerful JSON API over HTTP.  
@@ -21,10 +21,10 @@ The response consists of four objects:
 You may also obtain those objects individually using the URLs `/json/state` `/json/info` `/json/eff`, and `/json/pal`.
 
 !!! info "Reserved effect IDs"
-In WLED versions 0.14+, some effects are unsupported in certain builds (e.g. some audio reactive effects may only work on ESP32).
-In order for each effect to have an unique ID on all devices, having unsupported ones in between supported ones is possible.
-If called, these will fallback to the Solid effect, in the effects list they have the name `RSVD` or `-`.
-To improve user experience, it is recommended to remove effects with the names `RSVD` or `-` form the UI effect selection.
+    In WLED versions 0.14+, some effects are unsupported in certain builds (e.g. some audio reactive effects may only work on ESP32).
+    In order for each effect to have an unique ID on all devices, having unsupported ones in between supported ones is possible.
+    If called, these will fallback to the Solid effect, in the effects list they have the name `RSVD` or `-`.
+    To improve user experience, it is recommended to remove effects with the names `RSVD` or `-` form the UI effect selection.
 
 ### Example Library
 [WLED JSON API Library in rust](https://github.com/paulwrath1223/wled-json-api-library).
@@ -39,8 +39,8 @@ Example: `{"on":true,"bri":255}` sets the brightness to maximum. `{"seg":[{"col"
 `{"seg":[{"id":X,"on":"t"}]}` and replacing X with the desired segment ID will toggle on or off that segment.
 
 !!! tldr "CURL example"
-This will toggle on and off and return the new state (v0.13+):
-`curl -X POST "http://[WLED-IP]/json/state" -d '{"on":"t","v":true}' -H "Content-Type: application/json"`
+    This will toggle on and off and return the new state (v0.13+):
+    `curl -X POST "http://[WLED-IP]/json/state" -d '{"on":"t","v":true}' -H "Content-Type: application/json"`
 
 Sample JSON API response (v0.8.4):
 
@@ -270,15 +270,15 @@ To set ranges of LEDs, use the LED start and stop index followed by its color va
 `{"seg":{"i":[0,8,"FF0000", 10,18,"0000FF"]}}` sets the first eight LEDs to red, leaves out two, and sets another 8 to blue.
 
 To set a large number of colors, send multiple api calls of 256 colors at a time.  
-`{"seg": {"i":[0,"CC0000", "00CC00", "0000CC", "CC0000"...]}}`
+`{"seg": {"i":[0,"CC0000", "00CC00", "0000CC", "CC0000"...]}}` 
 `{"seg": {"i":[256, "CC0000", "00CC00", "0000CC", "CC0000"...]}}`
 `{"seg": {"i":[512, "CC0000", "00CC00", "0000CC", "CC0000"...]}}`
 
 Do not make several calls in parallel, that is not optimal for the device. Instead make your call in sequence, where each call waits for the previous to complete before making a new one. How this is done depends on your choice of tool, but with CURL you que your commands by separating then with ` && ` i.e. `CURL [command 1] && CURL [command 2] && CURL [command 3]`.
 
 !!! tip "Command buffer size"
-If you are trying to set many LEDs and it fails to work, you can check your request [here](https://arduinojson.org/v6/assistant) for length.
-Select ESP32 and Deserialize. If the required buffer size is above 10K for ESP8266 and 24K for ESP32, please split it into multiple sequential requests and consider using the Hex string syntax.
+    If you are trying to set many LEDs and it fails to work, you can check your request [here](https://arduinojson.org/v6/assistant) for length.
+    Select ESP32 and Deserialize. If the required buffer size is above 10K for ESP8266 and 24K for ESP32, please split it into multiple sequential requests and consider using the Hex string syntax.
 
 Keep in mind that the LED indices are segment-based, so LED 0 is the first LED of the segment, not of the entire strip.
 Segment features, including Grouping, Spacing, Mirroring and Reverse are functional.
@@ -286,7 +286,7 @@ Segment features, including Grouping, Spacing, Mirroring and Reverse are functio
 Matrices are handled as a non-serpentine layout.
 
 !!! info "Brightness interaction"
-For your colors to apply correctly, make sure the desired brightness is set beforehand. Turning on the LEDs from an off state and setting individual LEDs in the same JSON request will _not_ work!
+    For your colors to apply correctly, make sure the desired brightness is set beforehand. Turning on the LEDs from an off state and setting individual LEDs in the same JSON request will _not_ work!
 
 #### Playlists
 
@@ -323,7 +323,7 @@ end | Single preset ID to apply after the playlist finished. Has no effect when 
 In order to e.g. only show color controls relevant to a given setup, it is necessary to obtain the color capabilities of the light.  
 The `info.leds.seglc` array can be used to do so on a per-segment level. It contains `n+1` 8-bit integers, where `n` is the `id` of the last _active_ segment,
 each index corresponds to the segment with that ID.  
-This integer indicates whether a given segment supports (24 bit) RGB colors, an extra (8 bit) white channel and/or adjustable color temperature (CCT):
+This integer indicates whether a given segment supports (24 bit) RGB colors, an extra (8 bit) white channel and/or adjustable color temperature (CCT):  
 
 | Bit | Capability
 | --- | --- |
@@ -332,7 +332,7 @@ This integer indicates whether a given segment supports (24 bit) RGB colors, an 
 2 | Segment supports color temperature
 3-7 | Reserved (expect any value)
 
-Therefore:
+Therefore:  
 
 | `lc` value | Capabilities
 | --- | --- |
@@ -345,9 +345,9 @@ Therefore:
 6 | Supports CCT (including white channel) 
 7 | Supports CCT (including white channel) + RGB
 
-Note that CCT is controllable per-segment, while RGB color and white channel have 3 color slots each per segment.
-
-`info.leds.lc` contains this info on a global level, and is a bitwise AND of the per-segment light capability values.
+Note that CCT is controllable per-segment, while RGB color and white channel have 3 color slots each per segment.  
+  
+`info.leds.lc` contains this info on a global level, and is a bitwise AND of the per-segment light capability values.  
 
 #### CCT control
 
@@ -379,9 +379,9 @@ CCT support is indicated by `info.leds.cct` being `true`, in which case you can 
 #### Effect metadata
 
 !!! tip "Why effect metadata?"
-Prior to 0.14, user interfaces showed Speed and Intensity slider, palette controls, and all three color slots regardless of the effect selected.
-This may cause confusion to the user because controls are displayed that have no immediate effect in the current configuration.
-Effect metadata allows you to dynamically hide certain controls, so that the user only sees controls actually utilized by the selected effect mode.
+    Prior to 0.14, user interfaces showed Speed and Intensity slider, palette controls, and all three color slots regardless of the effect selected.
+    This may cause confusion to the user because controls are displayed that have no immediate effect in the current configuration.
+    Effect metadata allows you to dynamically hide certain controls, so that the user only sees controls actually utilized by the selected effect mode.
 
 Starting with WLED 0.14, effect metadata is available under the `/json/fxdata` URL.  
 This returns an array of strings with `info.fxcount` entries.
@@ -412,7 +412,7 @@ o3 | Option 3
 
 The fallback value if this section is missing is two sliders, Effect speed and Effect intensity.
 
-Examples:
+Examples:  
 
 | Parameter string | Displayed controls
 | --- | --- |
@@ -430,7 +430,7 @@ Up to 3 colors can be used. Please note that only the first two characters of th
 
 The fallback value if this section is missing is 3 colors: `Fx` + `Bg` + `Cs`.
 
-Examples:
+Examples:  
 
 | Colors string | Displayed controls
 | --- | --- |
@@ -477,7 +477,7 @@ If no default is specified for a given parameter, it retains the current value.
 ### Sensors
 
 !!! warning
-This section about the Sensor API is a DRAFT specification. It is not yet implemented and subject to change.
+    This section about the Sensor API is a DRAFT specification. It is not yet implemented and subject to change.
 
 Various types of sensors (e.g. for Temperature, light intensity, PIR) may be added to WLED via usermods.
 To allow read access to sensor data via the JSON API in a standardized way, the `info.sensor` array is used.

--- a/docs/interfaces/json-api.md
+++ b/docs/interfaces/json-api.md
@@ -1,8 +1,8 @@
 ---
 title: JSON API
 hide:
-  # - navigation
-  # - toc
+# - navigation
+# - toc
 ---
 
 WLED versions since 0.8.4 implement a powerful JSON API over HTTP.  
@@ -21,14 +21,14 @@ The response consists of four objects:
 You may also obtain those objects individually using the URLs `/json/state` `/json/info` `/json/eff`, and `/json/pal`.
 
 !!! info "Reserved effect IDs"
-    In WLED versions 0.14+, some effects are unsupported in certain builds (e.g. some audio reactive effects may only work on ESP32).
-    In order for each effect to have a unique ID on all devices, having unsupported ones in between supported ones is possible.
-    If called, these will fall back to the Solid effect, in the effects list they have the name `RSVD` or `-`.
-    To improve user experience, it is recommended to remove effects with the names `RSVD` or `-` form the UI effect selection.
+In WLED versions 0.14+, some effects are unsupported in certain builds (e.g. some audio reactive effects may only work on ESP32).
+In order for each effect to have an unique ID on all devices, having unsupported ones in between supported ones is possible.
+If called, these will fallback to the Solid effect, in the effects list they have the name `RSVD` or `-`.
+To improve user experience, it is recommended to remove effects with the names `RSVD` or `-` form the UI effect selection.
 
 ### Example Library
 [WLED JSON API Library in rust](https://github.com/paulwrath1223/wled-json-api-library).
-Even if you are not using rust, or don't know how to read rust, 
+Even if you are not using rust, or don't know how to read rust,
 the up-to-date JSON structure is included and documented in this project.
 
 
@@ -39,8 +39,8 @@ Example: `{"on":true,"bri":255}` sets the brightness to maximum. `{"seg":[{"col"
 `{"seg":[{"id":X,"on":"t"}]}` and replacing X with the desired segment ID will toggle on or off that segment.
 
 !!! tldr "CURL example"
-    This will toggle on and off and return the new state (v0.13+):
-    `curl -X POST "http://[WLED-IP]/json/state" -d '{"on":"t","v":true}' -H "Content-Type: application/json"`
+This will toggle on and off and return the new state (v0.13+):
+`curl -X POST "http://[WLED-IP]/json/state" -d '{"on":"t","v":true}' -H "Content-Type: application/json"`
 
 Sample JSON API response (v0.8.4):
 
@@ -130,36 +130,36 @@ Sample JSON API response (v0.8.4):
 
 #### State object
 
-| JSON key    | Value range              | Description                                                                                                                                                                                                                                                                                                                                                             |
-|-------------|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| on          | bool                     | On/Off state of the light                                                                                                                                                                                                                                                                                                                                               |
-| bri         | 0 to 255                 | Brightness of the light. If _on_ is `false`, contains last brightness when light was on (aka brightness when _on_ is set to true. Setting _bri_ to 0 is supported but it is recommended to use the range 1-255 and use `on: false` to turn off. The state response will never havethe value `0` for _bri_.                                                              |
-| transition  | 0 to 255                 | Duration of the crossfade between different colors/brightness levels. One unit is 100ms, so a value of `4` results in atransition of 400ms.                                                                                                                                                                                                                             |
-| tt          | 0 to 255                 | Similar to transition, but applies to just the current API call. Not included in state response.                                                                                                                                                                                                                                                                        |
-| ps          | -1 to 65535              | ID of currently set preset. `1~17~` can be used to iterate through presets 1-17.                                                                                                                                                                                                                                                                                        |
-| ~~pss~~     | 0 to 65535               | Bitwise indication of preset slots (0 - vacant, 1 - written). Always 0 in 0.11. Not changable. _Removed as of v0.11.1_                                                                                                                                                                                                                                                  |
-| psave       | 1 to 16 (250 in 0.11)    | Save current light config to specified preset slot. Not included in state response.                                                                                                                                                                                                                                                                                     |
-| pl          | -1 to 0                  | ID of currently set playlist. For now, this sets the preset cycle feature, `-1` is off and `0` is on.                                                                                                                                                                                                                                                                   |
-| nl.on       | bool                     | Nightlight currently active                                                                                                                                                                                                                                                                                                                                             |
-| nl.dur      | 1 to 255                 | Duration of nightlight in minutes                                                                                                                                                                                                                                                                                                                                       |
-| ~~nl.fade~~ | bool                     | If `true`, the light will gradually dim over the course of the nightlight duration. If `false`, it will instantly turn to the target brightness once the duration has elapsed. _Removed in 0.13.0_ (use mode instead)                                                                                                                                                   |
-| nl.mode     | 0 to 3                   | Nightlight mode (0: instant, 1: fade, 2: color fade, 3: sunrise) (available since 0.10.2)                                                                                                                                                                                                                                                                               |
-| nl.tbri     | 0 to 255                 | Target brightness of nightlight feature                                                                                                                                                                                                                                                                                                                                 |
-| nl.rem      | -1 to 15300              | Remaining nightlight duration in seconds, -1 if not active. Only in state response, can not be set.                                                                                                                                                                                                                                                                     |
-| udpn.send   | bool                     | Send WLED broadcast (UDP sync) packet on state change                                                                                                                                                                                                                                                                                                                   |
-| udpn.recv   | bool                     | Receive broadcast packets                                                                                                                                                                                                                                                                                                                                               |
-| udpn.sgrp   | 0 to 255                 | Bitfield for broadcast send groups 1-8                                                                                                                                                                                                                                                                                                                                  |
-| udpn.rgrp   | 0 to 255                 | Bitfield for broadcast receive groups 1-8                                                                                                                                                                                                                                                                                                                               |
-| udpn.nn     | bool                     | Don't send a broadcast packet (applies to just the current API call). Not included in state response.                                                                                                                                                                                                                                                                   |
-| v           | bool                     | If set to _true_ in a JSON POST command, the response will contain the full JSON state object. Not included in state response                                                                                                                                                                                                                                           |
-| rb          | bool                     | If set to _true_, device will reboot immediately. Not included in state response.                                                                                                                                                                                                                                                                                       |
-| live        | bool                     | If set to _true_, enters realtime mode and blanks the LEDs. The realtime timeout option does not have an effect when this command is used, WLED will stay in realtime mode until the state (color/effect/segments, excluding brightness) is changed. It is expected that `{"live":false}` is sent once live data sending is terminated. Not included in state response. |
-| lor         | 0, 1, or 2               | Live data override. 0 is off, 1 is override until live data ends, 2 is override until ESP reboot (available since 0.10.0)                                                                                                                                                                                                                                               |
-| time        | uint32                   | Set module time to unix timestamp. Not included in state response.                                                                                                                                                                                                                                                                                                      |
-| mainseg     | 0 to info.leds.maxseg-1  | Main Segment                                                                                                                                                                                                                                                                                                                                                            | Sets which segment ID is the main segment. The main segment's values are the ones sent by UDP sync, and in case no segment is selected, all changes done via the `"seg":{}` syntax without a segment `id` specified are applied to the main segment. If the main segment is deleted, the first active segment becomes the new main segment.
-| seg         | Array of segment objects | Segments are individual parts of the LED strip. In 0.9.0 this will enables running different effects on differentparts of the strip.                                                                                                                                                                                                                                    |
-| playlist    | object                   | [Custom preset playlists](#playlists). Not included in state response (available since 0.11.0)                                                                                                                                                                                                                                                                          |
-| tb          | uint32                   | Sets timebase for effects. Not reported.                                                                                                                                                                                                                                                                                                                                |
+| JSON key | Value range | Description
+| --- | --- | --- |
+on | bool | On/Off state of the light
+bri | 0 to 255 | Brightness of the light. If _on_ is `false`, contains last brightness when light was on (aka brightness when _on_ is set to true. Setting _bri_ to 0 is supported but it is recommended to use the range 1-255 and use `on: false` to turn off. The state response will never havethe value `0` for _bri_.
+transition | 0 to 255 | Duration of the crossfade between different colors/brightness levels. One unit is 100ms, so a value of `4` results in atransition of 400ms.
+tt | 0 to 255 | Similar to transition, but applies to just the current API call. Not included in state response.
+ps | -1 to 65535 | ID of currently set preset. `1~17~` can be used to iterate through presets 1-17.
+~~pss~~ | 0 to 65535 | Bitwise indication of preset slots (0 - vacant, 1 - written). Always 0 in 0.11. Not changable. _Removed as of v0.11.1_
+psave | 1 to 16 (250 in 0.11) | Save current light config to specified preset slot. Not included in state response.
+pl | -1 to 0 | ID of currently set playlist. For now, this sets the preset cycle feature, `-1` is off and `0` is on.
+nl.on | bool | Nightlight currently active
+nl.dur | 1 to 255 | Duration of nightlight in minutes
+~~nl.fade~~ | bool | If `true`, the light will gradually dim over the course of the nightlight duration. If `false`, it will instantly turn to the target brightness once the duration has elapsed. _Removed in 0.13.0_ (use mode instead)
+nl.mode | 0 to 3 | Nightlight mode (0: instant, 1: fade, 2: color fade, 3: sunrise) (available since 0.10.2)
+nl.tbri | 0 to 255 | Target brightness of nightlight feature
+nl.rem | -1 to 15300 | Remaining nightlight duration in seconds, -1 if not active. Only in state response, can not be set.
+udpn.send | bool | Send WLED broadcast (UDP sync) packet on state change
+udpn.recv | bool | Receive broadcast packets
+udpn.sgrp | 0 to 255 | Bitfield for broadcast send groups 1-8
+udpn.rgrp | 0 to 255 | Bitfield for broadcast receive groups 1-8
+udpn.nn | bool | Don't send a broadcast packet (applies to just the current API call). Not included in state response.
+v | bool | If set to _true_ in a JSON POST command, the response will contain the full JSON state object. Not included in state response
+rb | bool | If set to _true_, device will reboot immediately. Not included in state response.
+live | bool | If set to _true_, enters realtime mode and blanks the LEDs. The realtime timeout option does not have an effect when this command is used, WLED will stay in realtime mode until the state (color/effect/segments, excluding brightness) is changed. It is expected that `{"live":false}` is sent once live data sending is terminated. Not included in state response.
+lor | 0, 1, or 2 | Live data override. 0 is off, 1 is override until live data ends, 2 is override until ESP reboot (available since 0.10.0)
+time | uint32 | Set module time to unix timestamp. Not included in state response.
+mainseg | 0 to info.leds.maxseg-1 | Main Segment | Sets which segment ID is the main segment. The main segment's values are the ones sent by UDP sync, and in case no segment is selected, all changes done via the `"seg":{}` syntax without a segment `id` specified are applied to the main segment. If the main segment is deleted, the first active segment becomes the new main segment.
+seg | Array of segment objects | Segments are individual parts of the LED strip. In 0.9.0 this will enables running different effects on differentparts of the strip.
+playlist | object | [Custom preset playlists](#playlists). Not included in state response (available since 0.11.0)
+tb | uint32 | Sets timebase for effects. Not reported.
 
 #### Contents of the segment object
 
@@ -167,90 +167,90 @@ Sample JSON API response (v0.8.4):
 Unless stated otherwise, every value may be changed via an HTTP POST request.
 The tertiary color is not gamma-corrected in 0.8.4, but is in subsequent releases.
 
-| JSON key | Value range                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-|----------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| id       | 0 to info.maxseg -1                | Zero-indexed ID of the segment. May be omitted, in that case the ID will be inferred from the order of the segment objects in the _seg_ array.                                                                                                                                                                                                                                                                                                                                                                |
-| start    | 0 to info.leds.count -1            | LED the segment starts at.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| stop     | 0 to info.leds.count               | LED the segment stops at, not included in range. If _stop_ is set to a lower or equal value than _start_ (setting to `0` is recommended), the segment is invalidated and deleted.                                                                                                                                                                                                                                                                                                                             |
-| len      | 0 to info.leds.count               | Length of the segment (_stop_ - _start_). _stop_ has preference, so if it is included, _len_ is ignored.                                                                                                                                                                                                                                                                                                                                                                                                      |
-| grp      | 0 to 255                           | Grouping (how many consecutive LEDs of the same segment will be grouped to the same color)                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| spc      | 0 to 255                           | Spacing (how many LEDs are turned off and skipped between each group)                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| of       | -len+1 to len                      | Offset (how many LEDs to rotate the virtual start of the segments, available since 0.13.0)                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| col      | array of colors                    | Array that has up to 3 color arrays as elements, the primary, secondary (background) and tertiary colors of the segment. Each color is an array of 3 or 4 bytes, which represent an RGB(W) color.                                                                                                                                                                                                                                                                                                             |
-| fx       | 0 to info.fxcount -1               | ID of the effect or ~ to increment, ~- to decrement, or r for random.                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| sx       | 0 to 255                           | Relative effect speed. ~ to increment, ~- to decrement. ~10 to increment by 10, ~-10 to decrement by 10.                                                                                                                                                                                                                                                                                                                                                                                                      |
-| ix       | 0 to 255                           | Effect intensity. ~ to increment, ~- to decrement. ~10 to increment by 10, ~-10 to decrement by 10.                                                                                                                                                                                                                                                                                                                                                                                                           |
-| c1       | 0 to 255                           | Effect custom slider 1. Custom sliders are hidden or displayed and labeled based on [effect metadata](#effect-metadata).                                                                                                                                                                                                                                                                                                                                                                                      |
-| c2       | 0 to 255                           | Effect custom slider 2.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| c3       | 0 to 31                            | Effect custom slider 3.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| o1       | bool                               | Effect option 1. Custom options are hidden or displayed and labeled based on [effect metadata](#effect-metadata).                                                                                                                                                                                                                                                                                                                                                                                             |
-| o2       | bool                               | Effect option 2.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| o3       | bool                               | Effect option 3.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| pal      | 0 to info.palcount -1              | ID of the color palette or ~ to increment, ~- to decrement, or r for random.                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| sel      | bool                               | `true` if the segment is selected. Selected segments will have their state (color/FX) updated by APIs that don't support segments (e.g. UDP sync, HTTP API). If no segment is selected, the first segment (_id_:`0`) will behave as if selected. WLED will report the state of the first (lowest _id_) segment that is selected to APIs (HTTP, MQTT, Blynk...), or `mainseg` in case no segment is selected and for the UDP API. Live data is always applied to all LEDs regardless of segment configuration. |
-| rev      | bool                               | Flips the segment, causing animations to change direction.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| on       | bool                               | Turns on and off the individual segment. _(available since 0.10.0)_                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| bri      | 0 to 255                           | Sets the individual segment brightness _(available since 0.10.0)_                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| mi       | bool                               | Mirrors the segment _(available since 0.10.2)_                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| cct      | 0 to 255 _or_ 1900 to 10091        | White spectrum [color temperature](#cct-control) _(available since 0.13.0)_                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| lx       | `BBBGGGRRR`: 0 - 100100100         | Loxone RGB value for primary color. Each color (`RRR`,`GGG`,`BBB`) is specified in the range from 0 to 100%.                                                                                                                                                                                                                                                                                                                                                                                                  |
-| lx       | `20bbbtttt`: 200002700 - 201006500 | Loxone brightness and color temperature values for primary color. Brightness `bbb` is specified in the range 0 to 100%. `tttt` defines the color temperature in the range from 2700 to 6500 Kelvin. (available since 0.11.0, not included in state response)                                                                                                                                                                                                                                                  |
-| ly       | `BBBGGGRRR`: 0 - 100100100         | Loxone RGB value for secondary color. Each color (`RRR`,`GGG`,`BBB`) is specified in the range from 0 to 100%.                                                                                                                                                                                                                                                                                                                                                                                                |
-| ly       | `20bbbtttt`: 200002700 - 201006500 | Loxone brightness and color temperature values for secondary color. Brightness `bbb` is specified in the range 0 to 100%. `tttt` defines the color temperature in the range from 2700 to 6500 Kelvin. _(available since 0.11.0, not included in state response)_                                                                                                                                                                                                                                              |
-| i        | array                              | [Individual LED control](#per-segment-individual-led-control). Not included in state response _(available since 0.10.2)_                                                                                                                                                                                                                                                                                                                                                                                      |
-| frz      | bool                               | freezes/unfreezes the current effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| m12      | 0 to 4 [map1D2D.count]             | Setting of segment field 'Expand 1D FX'. (0: Pixels, 1: Bar, 2: Arc, 3: Corner)                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| si       | 0 to 3                             | Setting of the sound simulation type for audio enhanced effects. (0: 'BeatSin', 1: 'WeWillRockYou', 2: '10_3', 3: '14_3') (_as of 0.14.0-b1, there are these 4 types defined_)                                                                                                                                                                                                                                                                                                                                |
+| JSON key | Value range | Description
+| --- | --- | --- |
+id | 0 to info.maxseg -1 | Zero-indexed ID of the segment. May be omitted, in that case the ID will be inferred from the order of the segment objects in the _seg_ array.
+start | 0 to info.leds.count -1 | LED the segment starts at.
+stop | 0 to info.leds.count | LED the segment stops at, not included in range. If _stop_ is set to a lower or equal value than _start_ (setting to `0` is recommended), the segment is invalidated and deleted.
+len | 0 to info.leds.count | Length of the segment (_stop_ - _start_). _stop_ has preference, so if it is included, _len_ is ignored.
+grp | 0 to 255 | Grouping (how many consecutive LEDs of the same segment will be grouped to the same color)
+spc | 0 to 255 | Spacing (how many LEDs are turned off and skipped between each group)
+of | -len+1 to len | Offset (how many LEDs to rotate the virtual start of the segments, available since 0.13.0)
+col | array of colors | Array that has up to 3 color arrays as elements, the primary, secondary (background) and tertiary colors of the segment. Each color is an array of 3 or 4 bytes, which represent an RGB(W) color.
+fx | 0 to info.fxcount -1 | ID of the effect or ~ to increment, ~- to decrement, or r for random.
+sx | 0 to 255 | Relative effect speed. ~ to increment, ~- to decrement. ~10 to increment by 10, ~-10 to decrement by 10.
+ix | 0 to 255 | Effect intensity. ~ to increment, ~- to decrement. ~10 to increment by 10, ~-10 to decrement by 10.
+c1 | 0 to 255 | Effect custom slider 1. Custom sliders are hidden or displayed and labeled based on [effect metadata](#effect-metadata).
+c2 | 0 to 255 | Effect custom slider 2.
+c3 | 0 to 31 | Effect custom slider 3.
+o1 | bool | Effect option 1. Custom options are hidden or displayed and labeled based on [effect metadata](#effect-metadata).
+o2 | bool | Effect option 2.
+o3 | bool | Effect option 3.
+pal | 0 to info.palcount -1 | ID of the color palette or ~ to increment, ~- to decrement, or r for random.
+sel | bool | `true` if the segment is selected. Selected segments will have their state (color/FX) updated by APIs that don't support segments (e.g. UDP sync, HTTP API). If no segment is selected, the first segment (_id_:`0`) will behave as if selected. WLED will report the state of the first (lowest _id_) segment that is selected to APIs (HTTP, MQTT, Blynk...), or `mainseg` in case no segment is selected and for the UDP API. Live data is always applied to all LEDs regardless of segment configuration.
+rev | bool | Flips the segment, causing animations to change direction.
+on | bool | Turns on and off the individual segment. _(available since 0.10.0)_
+bri | 0 to 255 | Sets the individual segment brightness _(available since 0.10.0)_
+mi | bool | Mirrors the segment _(available since 0.10.2)_
+cct | 0 to 255 _or_ 1900 to 10091 | White spectrum [color temperature](#cct-control) _(available since 0.13.0)_
+lx | `BBBGGGRRR`: 0 - 100100100 | Loxone RGB value for primary color. Each color (`RRR`,`GGG`,`BBB`) is specified in the range from 0 to 100%.
+lx | `20bbbtttt`: 200002700 - 201006500 | Loxone brightness and color temperature values for primary color. Brightness `bbb` is specified in the range 0 to 100%. `tttt` defines the color temperature in the range from 2700 to 6500 Kelvin. (available since 0.11.0, not included in state response)
+ly | `BBBGGGRRR`: 0 - 100100100 | Loxone RGB value for secondary color. Each color (`RRR`,`GGG`,`BBB`) is specified in the range from 0 to 100%.
+ly | `20bbbtttt`: 200002700 - 201006500 | Loxone brightness and color temperature values for secondary color. Brightness `bbb` is specified in the range 0 to 100%. `tttt` defines the color temperature in the range from 2700 to 6500 Kelvin. _(available since 0.11.0, not included in state response)_
+i | array | [Individual LED control](#per-segment-individual-led-control). Not included in state response _(available since 0.10.2)_
+frz | bool | freezes/unfreezes the current effect
+m12 | 0 to 4 [map1D2D.count] | Setting of segment field 'Expand 1D FX'. (0: Pixels, 1: Bar, 2: Arc, 3: Corner)
+si | 0 to 3 | Setting of the sound simulation type for audio enhanced effects. (0: 'BeatSin', 1: 'WeWillRockYou', 2: '10_3', 3: '14_3') (_as of 0.14.0-b1, there are these 4 types defined_)
 
 #### Info object
 
 No value may be changed by means of this API.
 
-| JSON key     | Value range | Description                                                                                                                                                                                                                                                                                        |
-|--------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ver          | string      | Version name.                                                                                                                                                                                                                                                                                      |
-| vid          | uint32      | Build ID (YYMMDDB, B = daily build index).                                                                                                                                                                                                                                                         |
-| _leds_       | object      | Contains info about the LED setup.                                                                                                                                                                                                                                                                 |
-| leds.cct     | bool        | `true` if the light supports [color temperature control](#cct-control) _(available since 0.13.0, deprecated, use info.leds.lc)_                                                                                                                                                                    |
-| leds.count   | 1 to 1200   | Total LED count.                                                                                                                                                                                                                                                                                   |
-| leds.fps     | 0 to 255    | Current frames per second. _(available since 0.12.0)_                                                                                                                                                                                                                                              |
-| leds.rgbw    | bool        | `true` if LEDs are 4-channel (RGB + White). _(deprecated, use info.leds.lc)_                                                                                                                                                                                                                       |
-| leds.wv      | bool        | `true` if a white channel slider should be displayed. _(available since 0.10.0, deprecated, use info.leds.lc)_                                                                                                                                                                                     |
-| ~~leds.pin~~ | byte array  | LED strip pin(s). Always one element. _Removed as of v0.13_                                                                                                                                                                                                                                        |
-| leds.pwr     | 0 to 65000  | Current LED power usage in milliamps as determined by the ABL. `0` if ABL is disabled.                                                                                                                                                                                                             |
-| leds.maxpwr  | 0 to 65000  | Maximum power budget in milliamps for the ABL. `0` if ABL is disabled.                                                                                                                                                                                                                             |
-| leds.maxseg  | byte        | Maximum number of segments supported by this version.                                                                                                                                                                                                                                              |
-| leds.lc      | byte        | Logical AND of all active segment's virtual light capabilities                                                                                                                                                                                                                                     |
-| leds.seglc   | byte array  | Per-segment virtual light capabilities                                                                                                                                                                                                                                                             |
-| str          | bool        | If `true`, an UI with only a single button for toggling sync should toggle receive+send, otherwise send only                                                                                                                                                                                       |
-| name         | string      | Friendly name of the light. Intended for display in lists and titles.                                                                                                                                                                                                                              |
-| udpport      | uint16      | The UDP port for realtime packets and WLED broadcast.                                                                                                                                                                                                                                              |
-| live         | bool        | If `true`, the software is currently receiving realtime data via UDP or E1.31.                                                                                                                                                                                                                     |
-| lm           | string      | Info about the realtime data source                                                                                                                                                                                                                                                                |
-| lip          | string      | Realtime data source IP address                                                                                                                                                                                                                                                                    |
-| ws           | -1 to 8     | Number of currently connected WebSockets clients. -1 indicates that WS is unsupported in this build.                                                                                                                                                                                               |
-| fxcount      | byte        | Number of effects included.                                                                                                                                                                                                                                                                        |
-| palcount     | uint16      | Number of palettes configured.                                                                                                                                                                                                                                                                     |
-| _wifi_       | object      | Info about current signal strength                                                                                                                                                                                                                                                                 |
-| wifi.bssid   | string      | The BSSID of the currently connected network.                                                                                                                                                                                                                                                      |
-| wifi.signal  | 0 to 100    | Relative signal quality of the current connection.                                                                                                                                                                                                                                                 |
-| wifi.channel | 1 to 14     | The current WiFi channel.                                                                                                                                                                                                                                                                          |
-| _fs_         | object      | Info about the embedded LittleFS filesystem (since 0.11.0)                                                                                                                                                                                                                                         |
-| fs.u         | uint32      | Estimate of used filesystem space in kilobytes                                                                                                                                                                                                                                                     |
-| fs.t         | uint32      | Total filesystem size in kilobytes                                                                                                                                                                                                                                                                 |
-| fs.pmt       | uint32      | Unix timestamp for the last modification to the `presets.json` file. Not accurate after boot or after using `/edit`                                                                                                                                                                                |
-| ndc          | -1 to 255   | Number of other WLED devices discovered on the network. -1 if Node discovery disabled. (since 0.12.0)                                                                                                                                                                                              |
-| arch         | string      | Name of the platform.                                                                                                                                                                                                                                                                              |
-| core         | string      | Version of the underlying (Arduino core) SDK.                                                                                                                                                                                                                                                      |
-| lwip         | 0, 1, or 2  | Version of LwIP. 1 or 2 on ESP8266, 0 (does not apply) on ESP32. _Deprecated, removal in 0.14.0_                                                                                                                                                                                                   |
-| freeheap     | uint32      | Bytes of heap memory (RAM) currently available. Problematic if <`10k`.                                                                                                                                                                                                                             |
-| uptime       | uint32      | Time since the last boot/reset in seconds.                                                                                                                                                                                                                                                         |
-| opt          | uint16      | Used for debugging purposes only.                                                                                                                                                                                                                                                                  |
-| brand        | string      | The producer/vendor of the light. Always `WLED` for standard installations.                                                                                                                                                                                                                        |
-| product      | string      | The product name. Always `FOSS` for standard installations.                                                                                                                                                                                                                                        |
-| ~~btype~~    | string      | The origin of the build. `src` if a release version is compiled from source, `bin` for an official release image, `dev` for a development build (regardless of src/bin origin) and `exp` for experimental versions. `ogn` if the image is flashed to hardware by the vendor. _Removed as of v0.10_ |
-| mac          | string      | The hexadecimal hardware MAC address of the light, lowercase and without colons.                                                                                                                                                                                                                   |
-| ip           | string      | The IP address of this instance. Empty string if not connected. (since 0.13.0)                                                                                                                                                                                                                     |
+| JSON key | Value range | Description
+| --- | --- | --- |
+ver | string | Version name.
+vid | uint32 | Build ID (YYMMDDB, B = daily build index).
+_leds_ | object | Contains info about the LED setup.
+leds.cct | bool | `true` if the light supports [color temperature control](#cct-control) _(available since 0.13.0, deprecated, use info.leds.lc)_
+leds.count | 1 to 1200 | Total LED count.
+leds.fps | 0 to 255 | Current frames per second. _(available since 0.12.0)_
+leds.rgbw | bool | `true` if LEDs are 4-channel (RGB + White). _(deprecated, use info.leds.lc)_
+leds.wv | bool | `true` if a white channel slider should be displayed. _(available since 0.10.0, deprecated, use info.leds.lc)_
+~~leds.pin~~ | byte array | LED strip pin(s). Always one element. _Removed as of v0.13_
+leds.pwr | 0 to 65000 | Current LED power usage in milliamps as determined by the ABL. `0` if ABL is disabled.
+leds.maxpwr | 0 to 65000 | Maximum power budget in milliamps for the ABL. `0` if ABL is disabled.
+leds.maxseg | byte | Maximum number of segments supported by this version.
+leds.lc | byte | Logical AND of all active segment's virtual light capabilities
+leds.seglc | byte array | Per-segment virtual light capabilities
+str | bool | If `true`, an UI with only a single button for toggling sync should toggle receive+send, otherwise send only
+name | string | Friendly name of the light. Intended for display in lists and titles.
+udpport | uint16 | The UDP port for realtime packets and WLED broadcast.
+live | bool | If `true`, the software is currently receiving realtime data via UDP or E1.31.
+lm | string | Info about the realtime data source
+lip | string | Realtime data source IP address
+ws | -1 to 8 | Number of currently connected WebSockets clients. -1 indicates that WS is unsupported in this build.
+fxcount | byte | Number of effects included.
+palcount | uint16 | Number of palettes configured.
+_wifi_ | object | Info about current signal strength
+wifi.bssid | string | The BSSID of the currently connected network.
+wifi.signal | 0 to 100 | Relative signal quality of the current connection.
+wifi.channel | 1 to 14 | The current WiFi channel.
+_fs_ | object | Info about the embedded LittleFS filesystem (since 0.11.0)
+fs.u | uint32 | Estimate of used filesystem space in kilobytes
+fs.t | uint32 | Total filesystem size in kilobytes
+fs.pmt | uint32 | Unix timestamp for the last modification to the `presets.json` file. Not accurate after boot or after using `/edit`
+ndc | -1 to 255 | Number of other WLED devices discovered on the network. -1 if Node discovery disabled. (since 0.12.0)
+arch | string | Name of the platform.
+core | string | Version of the underlying (Arduino core) SDK.
+lwip | 0, 1, or 2 | Version of LwIP. 1 or 2 on ESP8266, 0 (does not apply) on ESP32. _Deprecated, removal in 0.14.0_
+freeheap | uint32 | Bytes of heap memory (RAM) currently available. Problematic if <`10k`.
+uptime | uint32 | Time since the last boot/reset in seconds.
+opt | uint16 | Used for debugging purposes only.
+brand | string | The producer/vendor of the light. Always `WLED` for standard installations.
+product | string | The product name. Always `FOSS` for standard installations.
+~~btype~~ | string | The origin of the build. `src` if a release version is compiled from source, `bin` for an official release image, `dev` for a development build (regardless of src/bin origin) and `exp` for experimental versions. `ogn` if the image is flashed to hardware by the vendor. _Removed as of v0.10_
+mac | string | The hexadecimal hardware MAC address of the light, lowercase and without colons.
+ip | string | The IP address of this instance. Empty string if not connected. (since 0.13.0)
 
 #### Per-segment individual LED control
 
@@ -270,15 +270,15 @@ To set ranges of LEDs, use the LED start and stop index followed by its color va
 `{"seg":{"i":[0,8,"FF0000", 10,18,"0000FF"]}}` sets the first eight LEDs to red, leaves out two, and sets another 8 to blue.
 
 To set a large number of colors, send multiple api calls of 256 colors at a time.  
-`{"seg": {"i":[0,"CC0000", "00CC00", "0000CC", "CC0000"...]}}` 
+`{"seg": {"i":[0,"CC0000", "00CC00", "0000CC", "CC0000"...]}}`
 `{"seg": {"i":[256, "CC0000", "00CC00", "0000CC", "CC0000"...]}}`
 `{"seg": {"i":[512, "CC0000", "00CC00", "0000CC", "CC0000"...]}}`
 
 Do not make several calls in parallel, that is not optimal for the device. Instead make your call in sequence, where each call waits for the previous to complete before making a new one. How this is done depends on your choice of tool, but with CURL you que your commands by separating then with ` && ` i.e. `CURL [command 1] && CURL [command 2] && CURL [command 3]`.
 
 !!! tip "Command buffer size"
-    If you are trying to set many LEDs and it fails to work, you can check your request [here](https://arduinojson.org/v6/assistant) for length.
-    Select ESP32 and Deserialize. If the required buffer size is above 10K for ESP8266 and 24K for ESP32, please split it into multiple sequential requests and consider using the Hex string syntax.
+If you are trying to set many LEDs and it fails to work, you can check your request [here](https://arduinojson.org/v6/assistant) for length.
+Select ESP32 and Deserialize. If the required buffer size is above 10K for ESP8266 and 24K for ESP32, please split it into multiple sequential requests and consider using the Hex string syntax.
 
 Keep in mind that the LED indices are segment-based, so LED 0 is the first LED of the segment, not of the entire strip.
 Segment features, including Grouping, Spacing, Mirroring and Reverse are functional.
@@ -286,7 +286,7 @@ Segment features, including Grouping, Spacing, Mirroring and Reverse are functio
 Matrices are handled as a non-serpentine layout.
 
 !!! info "Brightness interaction"
-    For your colors to apply correctly, make sure the desired brightness is set beforehand. Turning on the LEDs from an off state and setting individual LEDs in the same JSON request will _not_ work!
+For your colors to apply correctly, make sure the desired brightness is set beforehand. Turning on the LEDs from an off state and setting individual LEDs in the same JSON request will _not_ work!
 
 #### Playlists
 
@@ -310,44 +310,44 @@ This example applies preset ID 26 for 3 seconds, then preset 20 for 2 seconds, t
 
 Playlist object:
 
-| JSON key   | Description                                                                                                                                                                                                             |
-|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ps         | Array of preset ID integers to be applied in this order.                                                                                                                                                                |
-| dur        | Array of time each preset should be kept, in tenths of seconds. If only one integer is supplied, all presets will be kept for that time.Defaults to 10 seconds if not provided.                                         |
-| transition | Array of time each preset should transition to the next one, in tenths of seconds. If only one integer is supplied, all presets will transition for that time. Defaults to the current transition time if not provided. |
-| repeat     | How many times the entire playlist should cycle before finishing. Set to `0` for an indefinite cycle. Default to indefinite if not provided.                                                                            |
-| end        | Single preset ID to apply after the playlist finished. Has no effect when an indefinite cycle is set. If not provided, the light will stay on the last preset of the playlist.                                          |
+| JSON key | Description
+| --- | --- |
+ps | Array of preset ID integers to be applied in this order.
+dur | Array of time each preset should be kept, in tenths of seconds. If only one integer is supplied, all presets will be kept for that time.Defaults to 10 seconds if not provided.
+transition | Array of time each preset should transition to the next one, in tenths of seconds. If only one integer is supplied, all presets will transition for that time. Defaults to the current transition time if not provided.
+repeat | How many times the entire playlist should cycle before finishing. Set to `0` for an indefinite cycle. Default to indefinite if not provided.
+end | Single preset ID to apply after the playlist finished. Has no effect when an indefinite cycle is set. If not provided, the light will stay on the last preset of the playlist.
 
 #### Light capabilities
 
 In order to e.g. only show color controls relevant to a given setup, it is necessary to obtain the color capabilities of the light.  
 The `info.leds.seglc` array can be used to do so on a per-segment level. It contains `n+1` 8-bit integers, where `n` is the `id` of the last _active_ segment,
 each index corresponds to the segment with that ID.  
-This integer indicates whether a given segment supports (24 bit) RGB colors, an extra (8 bit) white channel and/or adjustable color temperature (CCT):  
+This integer indicates whether a given segment supports (24 bit) RGB colors, an extra (8 bit) white channel and/or adjustable color temperature (CCT):
 
-| Bit | Capability                         |
-|-----|------------------------------------|
-| 0   | Segment supports RGB color         |
-| 1   | Segment supports white channel     |
-| 2   | Segment supports color temperature |
-| 3-7 | Reserved (expect any value)        |
+| Bit | Capability
+| --- | --- |
+0 | Segment supports RGB color
+1 | Segment supports white channel
+2 | Segment supports color temperature
+3-7 | Reserved (expect any value)
 
-Therefore:  
+Therefore:
 
-| `lc` value | Capabilities                                                                                        |
-|------------|-----------------------------------------------------------------------------------------------------|
-| 0          | None. Indicates a segment that does not have a bus within its range, e.g. because it is not active. |
-| 1          | Supports RGB                                                                                        |
-| 2          | Supports white channel only                                                                         |
-| 3          | Supports RGBW                                                                                       |
-| 4          | Supports CCT only, no white channel (unused)                                                        |
-| 5          | Supports CCT + RGB, no white channel (unused)                                                       |
-| 6          | Supports CCT (including white channel)                                                              |
-| 7          | Supports CCT (including white channel) + RGB                                                        |
+| `lc` value | Capabilities
+| --- | --- |
+0 | None. Indicates a segment that does not have a bus within its range, e.g. because it is not active.
+1 | Supports RGB
+2 | Supports white channel only
+3 | Supports RGBW
+4 | Supports CCT only, no white channel (unused)
+5 | Supports CCT + RGB, no white channel (unused)
+6 | Supports CCT (including white channel) 
+7 | Supports CCT (including white channel) + RGB
 
-Note that CCT is controllable per-segment, while RGB color and white channel have 3 color slots each per segment.  
-  
-`info.leds.lc` contains this info on a global level, and is a bitwise AND of the per-segment light capability values.  
+Note that CCT is controllable per-segment, while RGB color and white channel have 3 color slots each per segment.
+
+`info.leds.lc` contains this info on a global level, and is a bitwise AND of the per-segment light capability values.
 
 #### CCT control
 
@@ -379,9 +379,9 @@ CCT support is indicated by `info.leds.cct` being `true`, in which case you can 
 #### Effect metadata
 
 !!! tip "Why effect metadata?"
-    Prior to 0.14, user interfaces showed Speed and Intensity slider, palette controls, and all three color slots regardless of the effect selected.
-    This may cause confusion to the user because controls are displayed that have no immediate effect in the current configuration.
-    Effect metadata allows you to dynamically hide certain controls, so that the user only sees controls actually utilized by the selected effect mode.
+Prior to 0.14, user interfaces showed Speed and Intensity slider, palette controls, and all three color slots regardless of the effect selected.
+This may cause confusion to the user because controls are displayed that have no immediate effect in the current configuration.
+Effect metadata allows you to dynamically hide certain controls, so that the user only sees controls actually utilized by the selected effect mode.
 
 Starting with WLED 0.14, effect metadata is available under the `/json/fxdata` URL.  
 This returns an array of strings with `info.fxcount` entries.
@@ -399,29 +399,29 @@ Slider/checkbox labels are comma separated.
 An empty or missing label disables this control.
 `!` specifies the default label is used:
 
-| Parameter | Default tooltip label |
-|-----------|-----------------------|
-| sx        | Effect speed          |
-| ix        | Effect intensity      |
-| c1        | Custom 1              |
-| c2        | Custom 2              |
-| c3        | Custom 3              |
-| o1        | Option 1              |
-| o2        | Option 2              |
-| o3        | Option 3              |
+| Parameter | Default tooltip label
+| --- | --- |
+sx | Effect speed
+ix | Effect intensity
+c1 | Custom 1
+c2 | Custom 2
+c3 | Custom 3
+o1 | Option 1
+o2 | Option 2
+o3 | Option 3
 
 The fallback value if this section is missing is two sliders, Effect speed and Effect intensity.
 
-Examples:  
+Examples:
 
-| Parameter string      | Displayed controls                                                 |
-|-----------------------|--------------------------------------------------------------------|
-| `<empty>`             | No effect parameters                                               |
-| !                     | 1 slider: Effect speed                                             |
-| !,!                   | 2 sliders: Effect speed + Effect intensity                         |
-| !,Phase               | 2 sliders: Effect speed + Phase                                    |
-| ,Saturation,,,,Invert | 1 slider (sets `ix` parameter) and 1 checkbox: Saturation + Invert |
-| ,,,,,Random colors    | 1 checkbox: Random colors                                          |
+| Parameter string | Displayed controls
+| --- | --- |
+`<empty>` | No effect parameters
+! | 1 slider: Effect speed
+!,! | 2 sliders: Effect speed + Effect intensity
+!,Phase | 2 sliders: Effect speed + Phase
+,Saturation,,,,Invert | 1 slider (sets `ix` parameter) and 1 checkbox: Saturation + Invert
+,,,,,Random colors | 1 checkbox: Random colors
 
 ##### Colors
 
@@ -430,15 +430,15 @@ Up to 3 colors can be used. Please note that only the first two characters of th
 
 The fallback value if this section is missing is 3 colors: `Fx` + `Bg` + `Cs`.
 
-Examples:  
+Examples:
 
-| Colors string | Displayed controls  |
-|---------------|---------------------|
-| `<empty>`     | No color controls   |
-| !             | 1 color: Fx         |
-| ,!            | 1 color: Bg         |
-| !,!           | 2 colors: Fx + Bg   |
-| 1,2,3         | 3 colors: 1 + 2 + 3 |
+| Colors string | Displayed controls
+| --- | --- |
+`<empty>` | No color controls
+! | 1 color: Fx
+,! | 1 color: Bg
+!,! | 2 colors: Fx + Bg
+1,2,3 | 3 colors: 1 + 2 + 3
 
 ##### Palette
 
@@ -452,14 +452,14 @@ Flags allow filtering for effects with certain characteristics.
 They are a single character each and not comma-separated.
 Currently, the following flags are specified:
 
-| Flag | Effect characteristic                                                                      |
-|------|--------------------------------------------------------------------------------------------|
-| 0    | Effect works well on a single LED. If flag 0 is present, flags 1/2/3 are omitted. (unused) |
-| 1    | Effect is optimized for use on 1D LED strips.                                              |
-| 2    | Effect requires a 2D matrix setup (unless flag 1 is also present)                          |
-| 3    | Effect requires a 3D cube (unless flags 1 and/or 2 are also present) (unused)              |
-| v    | Effect is audio reactive, reacts to amplitude/volume.                                      |
-| f    | Effect is audio reactive, reacts to audio frequency distribution.                          |
+| Flag | Effect characteristic
+| --- | --- |
+0 | Effect works well on a single LED. If flag 0 is present, flags 1/2/3 are omitted. (unused)
+1 | Effect is optimized for use on 1D LED strips.
+2 | Effect requires a 2D matrix setup (unless flag 1 is also present)
+3 | Effect requires a 3D cube (unless flags 1 and/or 2 are also present) (unused)
+v | Effect is audio reactive, reacts to amplitude/volume.
+f | Effect is audio reactive, reacts to audio frequency distribution.
 
 For example, a Flag string of `2v` denotes a volume reactive effect that is to be used on 2D matrices.
 
@@ -477,7 +477,7 @@ If no default is specified for a given parameter, it retains the current value.
 ### Sensors
 
 !!! warning
-    This section about the Sensor API is a DRAFT specification. It is not yet implemented and subject to change.
+This section about the Sensor API is a DRAFT specification. It is not yet implemented and subject to change.
 
 Various types of sensors (e.g. for Temperature, light intensity, PIR) may be added to WLED via usermods.
 To allow read access to sensor data via the JSON API in a standardized way, the `info.sensor` array is used.
@@ -498,49 +498,49 @@ refers to a 12 °C temperature measurement in Celsius with the sensor name "Outs
 
 The object may contain the following properties, of which all are optional, except `type`.
 
-| JSON key | Value range   | Description                                                                                                                                                                                                                                                                                                                       |
-|----------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| type     | string        | The type of the sensor.                                                                                                                                                                                                                                                                                                           |
-| n        | string        | The name of the sensor. If omitted, the client may generate a suitable name (e.g. "Temperature sensor 1")                                                                                                                                                                                                                         |
-| val      | any           | The most current sensor reading. May be of any JSON type depending on the type of the sensor, this is a number for all sensor types pre-defined below except for the `"b"` and `"CL"` types and custom type sensors. `null` if the reading is invalid, either due to an error or because the first reading has not yet completed. |
-| unit     | string        | An explicit human-readable unit string for the measurement. If omitted, the default for the sensor type is used.                                                                                                                                                                                                                  |
-| error    | int or string | If present and not `null`,`false`,`0` or an empty string, a sensor error is indicated. May either be an integer error code or an error string.                                                                                                                                                                                    |
-| tc       | number        | Seconds of WLED `uptime` when the value last changed substantially. The threshold for a "substantial" change is up to the implementation. This can for example be used to find when a PIR sensor was last activated.                                                                                                              |
-| tm       | number        | Seconds of WLED `uptime` when the last reading given by `val` was obtained.                                                                                                                                                                                                                                                       |
-| ts       | number        | Seconds of WLED `uptime` at the first measurement / start of measurement period. (required for Energy sensor type)                                                                                                                                                                                                                |
-| min      | number        | Lower bound of possible value range                                                                                                                                                                                                                                                                                               |
-| max      | number        | Upper bound of possible value range                                                                                                                                                                                                                                                                                               |
-| u        | number        | Absolute uncertainty of the measurement                                                                                                                                                                                                                                                                                           |
-| model    | string        | Identification of the sensor hardware used                                                                                                                                                                                                                                                                                        |
+| JSON key | Value range | Description
+| --- | --- | --- |
+type | string | The type of the sensor.
+n | string | The name of the sensor. If omitted, the client may generate a suitable name (e.g. "Temperature sensor 1") 
+val | any | The most current sensor reading. May be of any JSON type depending on the type of the sensor, this is a number for all sensor types pre-defined below except for the `"b"` and `"CL"` types and custom type sensors. `null` if the reading is invalid, either due to an error or because the first reading has not yet completed.
+unit | string | An explicit human-readable unit string for the measurement. If omitted, the default for the sensor type is used.
+error | int or string | If present and not `null`,`false`,`0` or an empty string, a sensor error is indicated. May either be an integer error code or an error string.
+tc | number | Seconds of WLED `uptime` when the value last changed substantially. The threshold for a "substantial" change is up to the implementation. This can for example be used to find when a PIR sensor was last activated. 
+tm | number | Seconds of WLED `uptime` when the last reading given by `val` was obtained.
+ts | number | Seconds of WLED `uptime` at the first measurement / start of measurement period. (required for Energy sensor type)
+min | number | Lower bound of possible value range
+max | number | Upper bound of possible value range
+u | number | Absolute uncertainty of the measurement
+model | string | Identification of the sensor hardware used
 
 #### Sensor types
 
 These are the standardized sensor types that may be implemented by usermods:
 
-| Type ID string    | Measurement type                                   | Default unit |
-|-------------------|----------------------------------------------------|--------------|
-| "" (empty string) | Invalid sensor (reserved)                          | -            |
-| b                 | Button/Boolean                                     | true/false   |
-| c                 | Custom user-defined sensor                         | -            |
-| q                 | Electric charge                                    | As           |
-| t                 | Time                                               | s            |
-| BL                | Battery Level                                      | %            |
-| CL                | 24-bit RGB color                                   | hex string   |
-| E                 | Energy (`ts` property required)                    | J            |
-| I                 | Electric current                                   | A            |
-| J                 | Illuminance                                        | lx           |
-| L                 | Distance                                           | m            |
-| Lp                | Sound pressure level                               | dB           |
-| M                 | Mass                                               | kg           |
-| N                 | Number/count                                       | -            |
-| P                 | Power                                              | W            |
-| Pe                | General purpose percentage                         | %            |
-| PL                | Power Level (signal strength)                      | dBm          |
-| Pr                | Pressure                                           | Pa           |
-| R                 | Electric Resistance                                | Ohms         |
-| RH                | Relative Humidity                                  | %            |
-| T                 | Temperature                                        | °C           |
-| U                 | Voltage                                            | V            |
-| (other strings)   | Reserved, let us know if you need a new type added | -            |
+| Type ID string | Measurement type | Default unit
+| --- | --- | --- |
+"" (empty string) | Invalid sensor (reserved) | - 
+b | Button/Boolean | true/false
+c | Custom user-defined sensor | -
+q | Electric charge | As
+t | Time | s
+BL| Battery Level | %
+CL| 24-bit RGB color | hex string
+E | Energy (`ts` property required) | J
+I | Electric current | A
+J | Illuminance | lx
+L | Distance | m
+Lp| Sound pressure level | dB
+M | Mass | kg
+N | Number/count | -
+P | Power | W
+Pe| General purpose percentage | %
+PL| Power Level (signal strength) | dBm
+Pr| Pressure | Pa
+R | Electric Resistance | Ohms
+RH| Relative Humidity | %
+T | Temperature | °C
+U | Voltage | V
+(other strings) | Reserved, let us know if you need a new type added | -
 
 If a client is only interested in certain sensor types (e.g. Temperature), it may disregard all other sensor objects.

--- a/docs/interfaces/json-api.md
+++ b/docs/interfaces/json-api.md
@@ -22,9 +22,15 @@ You may also obtain those objects individually using the URLs `/json/state` `/js
 
 !!! info "Reserved effect IDs"
     In WLED versions 0.14+, some effects are unsupported in certain builds (e.g. some audio reactive effects may only work on ESP32).
-    In order for each effect to have an unique ID on all devices, having unsupported ones in between supported ones is possible.
-    If called, these will fallback to the Solid effect, in the effects list they have the name `RSVD` or `-`.
+    In order for each effect to have a unique ID on all devices, having unsupported ones in between supported ones is possible.
+    If called, these will fall back to the Solid effect, in the effects list they have the name `RSVD` or `-`.
     To improve user experience, it is recommended to remove effects with the names `RSVD` or `-` form the UI effect selection.
+
+### Example Library
+[WLED JSON API Library in rust](https://github.com/paulwrath1223/wled-json-api-library).
+Even if you are not using rust, or don't know how to read rust, 
+the up-to-date JSON structure is included and documented in this project.
+
 
 ### Setting new values
 
@@ -124,36 +130,36 @@ Sample JSON API response (v0.8.4):
 
 #### State object
 
-| JSON key | Value range | Description
-| --- | --- | --- |
-on | bool | On/Off state of the light
-bri | 0 to 255 | Brightness of the light. If _on_ is `false`, contains last brightness when light was on (aka brightness when _on_ is set to true. Setting _bri_ to 0 is supported but it is recommended to use the range 1-255 and use `on: false` to turn off. The state response will never havethe value `0` for _bri_.
-transition | 0 to 255 | Duration of the crossfade between different colors/brightness levels. One unit is 100ms, so a value of `4` results in atransition of 400ms.
-tt | 0 to 255 | Similar to transition, but applies to just the current API call. Not included in state response.
-ps | -1 to 65535 | ID of currently set preset. `1~17~` can be used to iterate through presets 1-17.
-~~pss~~ | 0 to 65535 | Bitwise indication of preset slots (0 - vacant, 1 - written). Always 0 in 0.11. Not changable. _Removed as of v0.11.1_
-psave | 1 to 16 (250 in 0.11) | Save current light config to specified preset slot. Not included in state response.
-pl | -1 to 0 | ID of currently set playlist. For now, this sets the preset cycle feature, `-1` is off and `0` is on.
-nl.on | bool | Nightlight currently active
-nl.dur | 1 to 255 | Duration of nightlight in minutes
-~~nl.fade~~ | bool | If `true`, the light will gradually dim over the course of the nightlight duration. If `false`, it will instantly turn to the target brightness once the duration has elapsed. _Removed in 0.13.0_ (use mode instead)
-nl.mode | 0 to 3 | Nightlight mode (0: instant, 1: fade, 2: color fade, 3: sunrise) (available since 0.10.2)
-nl.tbri | 0 to 255 | Target brightness of nightlight feature
-nl.rem | -1 to 15300 | Remaining nightlight duration in seconds, -1 if not active. Only in state response, can not be set.
-udpn.send | bool | Send WLED broadcast (UDP sync) packet on state change
-udpn.recv | bool | Receive broadcast packets
-udpn.sgrp | 0 to 255 | Bitfield for broadcast send groups 1-8
-udpn.rgrp | 0 to 255 | Bitfield for broadcast receive groups 1-8
-udpn.nn | bool | Don't send a broadcast packet (applies to just the current API call). Not included in state response.
-v | bool | If set to _true_ in a JSON POST command, the response will contain the full JSON state object. Not included in state response
-rb | bool | If set to _true_, device will reboot immediately. Not included in state response.
-live | bool | If set to _true_, enters realtime mode and blanks the LEDs. The realtime timeout option does not have an effect when this command is used, WLED will stay in realtime mode until the state (color/effect/segments, excluding brightness) is changed. It is expected that `{"live":false}` is sent once live data sending is terminated. Not included in state response.
-lor | 0, 1, or 2 | Live data override. 0 is off, 1 is override until live data ends, 2 is override until ESP reboot (available since 0.10.0)
-time | uint32 | Set module time to unix timestamp. Not included in state response.
-mainseg | 0 to info.leds.maxseg-1 | Main Segment | Sets which segment ID is the main segment. The main segment's values are the ones sent by UDP sync, and in case no segment is selected, all changes done via the `"seg":{}` syntax without a segment `id` specified are applied to the main segment. If the main segment is deleted, the first active segment becomes the new main segment.
-seg | Array of segment objects | Segments are individual parts of the LED strip. In 0.9.0 this will enables running different effects on differentparts of the strip.
-playlist | object | [Custom preset playlists](#playlists). Not included in state response (available since 0.11.0)
-tb | uint32 | Sets timebase for effects. Not reported.
+| JSON key    | Value range              | Description                                                                                                                                                                                                                                                                                                                                                             |
+|-------------|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| on          | bool                     | On/Off state of the light                                                                                                                                                                                                                                                                                                                                               |
+| bri         | 0 to 255                 | Brightness of the light. If _on_ is `false`, contains last brightness when light was on (aka brightness when _on_ is set to true. Setting _bri_ to 0 is supported but it is recommended to use the range 1-255 and use `on: false` to turn off. The state response will never havethe value `0` for _bri_.                                                              |
+| transition  | 0 to 255                 | Duration of the crossfade between different colors/brightness levels. One unit is 100ms, so a value of `4` results in atransition of 400ms.                                                                                                                                                                                                                             |
+| tt          | 0 to 255                 | Similar to transition, but applies to just the current API call. Not included in state response.                                                                                                                                                                                                                                                                        |
+| ps          | -1 to 65535              | ID of currently set preset. `1~17~` can be used to iterate through presets 1-17.                                                                                                                                                                                                                                                                                        |
+| ~~pss~~     | 0 to 65535               | Bitwise indication of preset slots (0 - vacant, 1 - written). Always 0 in 0.11. Not changable. _Removed as of v0.11.1_                                                                                                                                                                                                                                                  |
+| psave       | 1 to 16 (250 in 0.11)    | Save current light config to specified preset slot. Not included in state response.                                                                                                                                                                                                                                                                                     |
+| pl          | -1 to 0                  | ID of currently set playlist. For now, this sets the preset cycle feature, `-1` is off and `0` is on.                                                                                                                                                                                                                                                                   |
+| nl.on       | bool                     | Nightlight currently active                                                                                                                                                                                                                                                                                                                                             |
+| nl.dur      | 1 to 255                 | Duration of nightlight in minutes                                                                                                                                                                                                                                                                                                                                       |
+| ~~nl.fade~~ | bool                     | If `true`, the light will gradually dim over the course of the nightlight duration. If `false`, it will instantly turn to the target brightness once the duration has elapsed. _Removed in 0.13.0_ (use mode instead)                                                                                                                                                   |
+| nl.mode     | 0 to 3                   | Nightlight mode (0: instant, 1: fade, 2: color fade, 3: sunrise) (available since 0.10.2)                                                                                                                                                                                                                                                                               |
+| nl.tbri     | 0 to 255                 | Target brightness of nightlight feature                                                                                                                                                                                                                                                                                                                                 |
+| nl.rem      | -1 to 15300              | Remaining nightlight duration in seconds, -1 if not active. Only in state response, can not be set.                                                                                                                                                                                                                                                                     |
+| udpn.send   | bool                     | Send WLED broadcast (UDP sync) packet on state change                                                                                                                                                                                                                                                                                                                   |
+| udpn.recv   | bool                     | Receive broadcast packets                                                                                                                                                                                                                                                                                                                                               |
+| udpn.sgrp   | 0 to 255                 | Bitfield for broadcast send groups 1-8                                                                                                                                                                                                                                                                                                                                  |
+| udpn.rgrp   | 0 to 255                 | Bitfield for broadcast receive groups 1-8                                                                                                                                                                                                                                                                                                                               |
+| udpn.nn     | bool                     | Don't send a broadcast packet (applies to just the current API call). Not included in state response.                                                                                                                                                                                                                                                                   |
+| v           | bool                     | If set to _true_ in a JSON POST command, the response will contain the full JSON state object. Not included in state response                                                                                                                                                                                                                                           |
+| rb          | bool                     | If set to _true_, device will reboot immediately. Not included in state response.                                                                                                                                                                                                                                                                                       |
+| live        | bool                     | If set to _true_, enters realtime mode and blanks the LEDs. The realtime timeout option does not have an effect when this command is used, WLED will stay in realtime mode until the state (color/effect/segments, excluding brightness) is changed. It is expected that `{"live":false}` is sent once live data sending is terminated. Not included in state response. |
+| lor         | 0, 1, or 2               | Live data override. 0 is off, 1 is override until live data ends, 2 is override until ESP reboot (available since 0.10.0)                                                                                                                                                                                                                                               |
+| time        | uint32                   | Set module time to unix timestamp. Not included in state response.                                                                                                                                                                                                                                                                                                      |
+| mainseg     | 0 to info.leds.maxseg-1  | Main Segment                                                                                                                                                                                                                                                                                                                                                            | Sets which segment ID is the main segment. The main segment's values are the ones sent by UDP sync, and in case no segment is selected, all changes done via the `"seg":{}` syntax without a segment `id` specified are applied to the main segment. If the main segment is deleted, the first active segment becomes the new main segment.
+| seg         | Array of segment objects | Segments are individual parts of the LED strip. In 0.9.0 this will enables running different effects on differentparts of the strip.                                                                                                                                                                                                                                    |
+| playlist    | object                   | [Custom preset playlists](#playlists). Not included in state response (available since 0.11.0)                                                                                                                                                                                                                                                                          |
+| tb          | uint32                   | Sets timebase for effects. Not reported.                                                                                                                                                                                                                                                                                                                                |
 
 #### Contents of the segment object
 
@@ -161,90 +167,90 @@ tb | uint32 | Sets timebase for effects. Not reported.
 Unless stated otherwise, every value may be changed via an HTTP POST request.
 The tertiary color is not gamma-corrected in 0.8.4, but is in subsequent releases.
 
-| JSON key | Value range | Description
-| --- | --- | --- |
-id | 0 to info.maxseg -1 | Zero-indexed ID of the segment. May be omitted, in that case the ID will be inferred from the order of the segment objects in the _seg_ array.
-start | 0 to info.leds.count -1 | LED the segment starts at.
-stop | 0 to info.leds.count | LED the segment stops at, not included in range. If _stop_ is set to a lower or equal value than _start_ (setting to `0` is recommended), the segment is invalidated and deleted.
-len | 0 to info.leds.count | Length of the segment (_stop_ - _start_). _stop_ has preference, so if it is included, _len_ is ignored.
-grp | 0 to 255 | Grouping (how many consecutive LEDs of the same segment will be grouped to the same color)
-spc | 0 to 255 | Spacing (how many LEDs are turned off and skipped between each group)
-of | -len+1 to len | Offset (how many LEDs to rotate the virtual start of the segments, available since 0.13.0)
-col | array of colors | Array that has up to 3 color arrays as elements, the primary, secondary (background) and tertiary colors of the segment. Each color is an array of 3 or 4 bytes, which represent an RGB(W) color.
-fx | 0 to info.fxcount -1 | ID of the effect or ~ to increment, ~- to decrement, or r for random.
-sx | 0 to 255 | Relative effect speed. ~ to increment, ~- to decrement. ~10 to increment by 10, ~-10 to decrement by 10.
-ix | 0 to 255 | Effect intensity. ~ to increment, ~- to decrement. ~10 to increment by 10, ~-10 to decrement by 10.
-c1 | 0 to 255 | Effect custom slider 1. Custom sliders are hidden or displayed and labeled based on [effect metadata](#effect-metadata).
-c2 | 0 to 255 | Effect custom slider 2.
-c3 | 0 to 31 | Effect custom slider 3.
-o1 | bool | Effect option 1. Custom options are hidden or displayed and labeled based on [effect metadata](#effect-metadata).
-o2 | bool | Effect option 2.
-o3 | bool | Effect option 3.
-pal | 0 to info.palcount -1 | ID of the color palette or ~ to increment, ~- to decrement, or r for random.
-sel | bool | `true` if the segment is selected. Selected segments will have their state (color/FX) updated by APIs that don't support segments (e.g. UDP sync, HTTP API). If no segment is selected, the first segment (_id_:`0`) will behave as if selected. WLED will report the state of the first (lowest _id_) segment that is selected to APIs (HTTP, MQTT, Blynk...), or `mainseg` in case no segment is selected and for the UDP API. Live data is always applied to all LEDs regardless of segment configuration.
-rev | bool | Flips the segment, causing animations to change direction.
-on | bool | Turns on and off the individual segment. _(available since 0.10.0)_
-bri | 0 to 255 | Sets the individual segment brightness _(available since 0.10.0)_
-mi | bool | Mirrors the segment _(available since 0.10.2)_
-cct | 0 to 255 _or_ 1900 to 10091 | White spectrum [color temperature](#cct-control) _(available since 0.13.0)_
-lx | `BBBGGGRRR`: 0 - 100100100 | Loxone RGB value for primary color. Each color (`RRR`,`GGG`,`BBB`) is specified in the range from 0 to 100%.
-lx | `20bbbtttt`: 200002700 - 201006500 | Loxone brightness and color temperature values for primary color. Brightness `bbb` is specified in the range 0 to 100%. `tttt` defines the color temperature in the range from 2700 to 6500 Kelvin. (available since 0.11.0, not included in state response)
-ly | `BBBGGGRRR`: 0 - 100100100 | Loxone RGB value for secondary color. Each color (`RRR`,`GGG`,`BBB`) is specified in the range from 0 to 100%.
-ly | `20bbbtttt`: 200002700 - 201006500 | Loxone brightness and color temperature values for secondary color. Brightness `bbb` is specified in the range 0 to 100%. `tttt` defines the color temperature in the range from 2700 to 6500 Kelvin. _(available since 0.11.0, not included in state response)_
-i | array | [Individual LED control](#per-segment-individual-led-control). Not included in state response _(available since 0.10.2)_
-frz | bool | freezes/unfreezes the current effect
-m12 | 0 to 4 [map1D2D.count] | Setting of segment field 'Expand 1D FX'. (0: Pixels, 1: Bar, 2: Arc, 3: Corner)
-si | 0 to 3 | Setting of the sound simulation type for audio enhanced effects. (0: 'BeatSin', 1: 'WeWillRockYou', 2: '10_3', 3: '14_3') (_as of 0.14.0-b1, there are these 4 types defined_)
+| JSON key | Value range                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+|----------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id       | 0 to info.maxseg -1                | Zero-indexed ID of the segment. May be omitted, in that case the ID will be inferred from the order of the segment objects in the _seg_ array.                                                                                                                                                                                                                                                                                                                                                                |
+| start    | 0 to info.leds.count -1            | LED the segment starts at.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| stop     | 0 to info.leds.count               | LED the segment stops at, not included in range. If _stop_ is set to a lower or equal value than _start_ (setting to `0` is recommended), the segment is invalidated and deleted.                                                                                                                                                                                                                                                                                                                             |
+| len      | 0 to info.leds.count               | Length of the segment (_stop_ - _start_). _stop_ has preference, so if it is included, _len_ is ignored.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| grp      | 0 to 255                           | Grouping (how many consecutive LEDs of the same segment will be grouped to the same color)                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| spc      | 0 to 255                           | Spacing (how many LEDs are turned off and skipped between each group)                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| of       | -len+1 to len                      | Offset (how many LEDs to rotate the virtual start of the segments, available since 0.13.0)                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| col      | array of colors                    | Array that has up to 3 color arrays as elements, the primary, secondary (background) and tertiary colors of the segment. Each color is an array of 3 or 4 bytes, which represent an RGB(W) color.                                                                                                                                                                                                                                                                                                             |
+| fx       | 0 to info.fxcount -1               | ID of the effect or ~ to increment, ~- to decrement, or r for random.                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| sx       | 0 to 255                           | Relative effect speed. ~ to increment, ~- to decrement. ~10 to increment by 10, ~-10 to decrement by 10.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ix       | 0 to 255                           | Effect intensity. ~ to increment, ~- to decrement. ~10 to increment by 10, ~-10 to decrement by 10.                                                                                                                                                                                                                                                                                                                                                                                                           |
+| c1       | 0 to 255                           | Effect custom slider 1. Custom sliders are hidden or displayed and labeled based on [effect metadata](#effect-metadata).                                                                                                                                                                                                                                                                                                                                                                                      |
+| c2       | 0 to 255                           | Effect custom slider 2.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| c3       | 0 to 31                            | Effect custom slider 3.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| o1       | bool                               | Effect option 1. Custom options are hidden or displayed and labeled based on [effect metadata](#effect-metadata).                                                                                                                                                                                                                                                                                                                                                                                             |
+| o2       | bool                               | Effect option 2.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| o3       | bool                               | Effect option 3.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| pal      | 0 to info.palcount -1              | ID of the color palette or ~ to increment, ~- to decrement, or r for random.                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| sel      | bool                               | `true` if the segment is selected. Selected segments will have their state (color/FX) updated by APIs that don't support segments (e.g. UDP sync, HTTP API). If no segment is selected, the first segment (_id_:`0`) will behave as if selected. WLED will report the state of the first (lowest _id_) segment that is selected to APIs (HTTP, MQTT, Blynk...), or `mainseg` in case no segment is selected and for the UDP API. Live data is always applied to all LEDs regardless of segment configuration. |
+| rev      | bool                               | Flips the segment, causing animations to change direction.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| on       | bool                               | Turns on and off the individual segment. _(available since 0.10.0)_                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| bri      | 0 to 255                           | Sets the individual segment brightness _(available since 0.10.0)_                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| mi       | bool                               | Mirrors the segment _(available since 0.10.2)_                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| cct      | 0 to 255 _or_ 1900 to 10091        | White spectrum [color temperature](#cct-control) _(available since 0.13.0)_                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| lx       | `BBBGGGRRR`: 0 - 100100100         | Loxone RGB value for primary color. Each color (`RRR`,`GGG`,`BBB`) is specified in the range from 0 to 100%.                                                                                                                                                                                                                                                                                                                                                                                                  |
+| lx       | `20bbbtttt`: 200002700 - 201006500 | Loxone brightness and color temperature values for primary color. Brightness `bbb` is specified in the range 0 to 100%. `tttt` defines the color temperature in the range from 2700 to 6500 Kelvin. (available since 0.11.0, not included in state response)                                                                                                                                                                                                                                                  |
+| ly       | `BBBGGGRRR`: 0 - 100100100         | Loxone RGB value for secondary color. Each color (`RRR`,`GGG`,`BBB`) is specified in the range from 0 to 100%.                                                                                                                                                                                                                                                                                                                                                                                                |
+| ly       | `20bbbtttt`: 200002700 - 201006500 | Loxone brightness and color temperature values for secondary color. Brightness `bbb` is specified in the range 0 to 100%. `tttt` defines the color temperature in the range from 2700 to 6500 Kelvin. _(available since 0.11.0, not included in state response)_                                                                                                                                                                                                                                              |
+| i        | array                              | [Individual LED control](#per-segment-individual-led-control). Not included in state response _(available since 0.10.2)_                                                                                                                                                                                                                                                                                                                                                                                      |
+| frz      | bool                               | freezes/unfreezes the current effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| m12      | 0 to 4 [map1D2D.count]             | Setting of segment field 'Expand 1D FX'. (0: Pixels, 1: Bar, 2: Arc, 3: Corner)                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| si       | 0 to 3                             | Setting of the sound simulation type for audio enhanced effects. (0: 'BeatSin', 1: 'WeWillRockYou', 2: '10_3', 3: '14_3') (_as of 0.14.0-b1, there are these 4 types defined_)                                                                                                                                                                                                                                                                                                                                |
 
 #### Info object
 
 No value may be changed by means of this API.
 
-| JSON key | Value range | Description
-| --- | --- | --- |
-ver | string | Version name.
-vid | uint32 | Build ID (YYMMDDB, B = daily build index).
-_leds_ | object | Contains info about the LED setup.
-leds.cct | bool | `true` if the light supports [color temperature control](#cct-control) _(available since 0.13.0, deprecated, use info.leds.lc)_
-leds.count | 1 to 1200 | Total LED count.
-leds.fps | 0 to 255 | Current frames per second. _(available since 0.12.0)_
-leds.rgbw | bool | `true` if LEDs are 4-channel (RGB + White). _(deprecated, use info.leds.lc)_
-leds.wv | bool | `true` if a white channel slider should be displayed. _(available since 0.10.0, deprecated, use info.leds.lc)_
-~~leds.pin~~ | byte array | LED strip pin(s). Always one element. _Removed as of v0.13_
-leds.pwr | 0 to 65000 | Current LED power usage in milliamps as determined by the ABL. `0` if ABL is disabled.
-leds.maxpwr | 0 to 65000 | Maximum power budget in milliamps for the ABL. `0` if ABL is disabled.
-leds.maxseg | byte | Maximum number of segments supported by this version.
-leds.lc | byte | Logical AND of all active segment's virtual light capabilities
-leds.seglc | byte array | Per-segment virtual light capabilities
-str | bool | If `true`, an UI with only a single button for toggling sync should toggle receive+send, otherwise send only
-name | string | Friendly name of the light. Intended for display in lists and titles.
-udpport | uint16 | The UDP port for realtime packets and WLED broadcast.
-live | bool | If `true`, the software is currently receiving realtime data via UDP or E1.31.
-lm | string | Info about the realtime data source
-lip | string | Realtime data source IP address
-ws | -1 to 8 | Number of currently connected WebSockets clients. -1 indicates that WS is unsupported in this build.
-fxcount | byte | Number of effects included.
-palcount | uint16 | Number of palettes configured.
-_wifi_ | object | Info about current signal strength
-wifi.bssid | string | The BSSID of the currently connected network.
-wifi.signal | 0 to 100 | Relative signal quality of the current connection.
-wifi.channel | 1 to 14 | The current WiFi channel.
-_fs_ | object | Info about the embedded LittleFS filesystem (since 0.11.0)
-fs.u | uint32 | Estimate of used filesystem space in kilobytes
-fs.t | uint32 | Total filesystem size in kilobytes
-fs.pmt | uint32 | Unix timestamp for the last modification to the `presets.json` file. Not accurate after boot or after using `/edit`
-ndc | -1 to 255 | Number of other WLED devices discovered on the network. -1 if Node discovery disabled. (since 0.12.0)
-arch | string | Name of the platform.
-core | string | Version of the underlying (Arduino core) SDK.
-lwip | 0, 1, or 2 | Version of LwIP. 1 or 2 on ESP8266, 0 (does not apply) on ESP32. _Deprecated, removal in 0.14.0_
-freeheap | uint32 | Bytes of heap memory (RAM) currently available. Problematic if <`10k`.
-uptime | uint32 | Time since the last boot/reset in seconds.
-opt | uint16 | Used for debugging purposes only.
-brand | string | The producer/vendor of the light. Always `WLED` for standard installations.
-product | string | The product name. Always `FOSS` for standard installations.
-~~btype~~ | string | The origin of the build. `src` if a release version is compiled from source, `bin` for an official release image, `dev` for a development build (regardless of src/bin origin) and `exp` for experimental versions. `ogn` if the image is flashed to hardware by the vendor. _Removed as of v0.10_
-mac | string | The hexadecimal hardware MAC address of the light, lowercase and without colons.
-ip | string | The IP address of this instance. Empty string if not connected. (since 0.13.0)
+| JSON key     | Value range | Description                                                                                                                                                                                                                                                                                        |
+|--------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ver          | string      | Version name.                                                                                                                                                                                                                                                                                      |
+| vid          | uint32      | Build ID (YYMMDDB, B = daily build index).                                                                                                                                                                                                                                                         |
+| _leds_       | object      | Contains info about the LED setup.                                                                                                                                                                                                                                                                 |
+| leds.cct     | bool        | `true` if the light supports [color temperature control](#cct-control) _(available since 0.13.0, deprecated, use info.leds.lc)_                                                                                                                                                                    |
+| leds.count   | 1 to 1200   | Total LED count.                                                                                                                                                                                                                                                                                   |
+| leds.fps     | 0 to 255    | Current frames per second. _(available since 0.12.0)_                                                                                                                                                                                                                                              |
+| leds.rgbw    | bool        | `true` if LEDs are 4-channel (RGB + White). _(deprecated, use info.leds.lc)_                                                                                                                                                                                                                       |
+| leds.wv      | bool        | `true` if a white channel slider should be displayed. _(available since 0.10.0, deprecated, use info.leds.lc)_                                                                                                                                                                                     |
+| ~~leds.pin~~ | byte array  | LED strip pin(s). Always one element. _Removed as of v0.13_                                                                                                                                                                                                                                        |
+| leds.pwr     | 0 to 65000  | Current LED power usage in milliamps as determined by the ABL. `0` if ABL is disabled.                                                                                                                                                                                                             |
+| leds.maxpwr  | 0 to 65000  | Maximum power budget in milliamps for the ABL. `0` if ABL is disabled.                                                                                                                                                                                                                             |
+| leds.maxseg  | byte        | Maximum number of segments supported by this version.                                                                                                                                                                                                                                              |
+| leds.lc      | byte        | Logical AND of all active segment's virtual light capabilities                                                                                                                                                                                                                                     |
+| leds.seglc   | byte array  | Per-segment virtual light capabilities                                                                                                                                                                                                                                                             |
+| str          | bool        | If `true`, an UI with only a single button for toggling sync should toggle receive+send, otherwise send only                                                                                                                                                                                       |
+| name         | string      | Friendly name of the light. Intended for display in lists and titles.                                                                                                                                                                                                                              |
+| udpport      | uint16      | The UDP port for realtime packets and WLED broadcast.                                                                                                                                                                                                                                              |
+| live         | bool        | If `true`, the software is currently receiving realtime data via UDP or E1.31.                                                                                                                                                                                                                     |
+| lm           | string      | Info about the realtime data source                                                                                                                                                                                                                                                                |
+| lip          | string      | Realtime data source IP address                                                                                                                                                                                                                                                                    |
+| ws           | -1 to 8     | Number of currently connected WebSockets clients. -1 indicates that WS is unsupported in this build.                                                                                                                                                                                               |
+| fxcount      | byte        | Number of effects included.                                                                                                                                                                                                                                                                        |
+| palcount     | uint16      | Number of palettes configured.                                                                                                                                                                                                                                                                     |
+| _wifi_       | object      | Info about current signal strength                                                                                                                                                                                                                                                                 |
+| wifi.bssid   | string      | The BSSID of the currently connected network.                                                                                                                                                                                                                                                      |
+| wifi.signal  | 0 to 100    | Relative signal quality of the current connection.                                                                                                                                                                                                                                                 |
+| wifi.channel | 1 to 14     | The current WiFi channel.                                                                                                                                                                                                                                                                          |
+| _fs_         | object      | Info about the embedded LittleFS filesystem (since 0.11.0)                                                                                                                                                                                                                                         |
+| fs.u         | uint32      | Estimate of used filesystem space in kilobytes                                                                                                                                                                                                                                                     |
+| fs.t         | uint32      | Total filesystem size in kilobytes                                                                                                                                                                                                                                                                 |
+| fs.pmt       | uint32      | Unix timestamp for the last modification to the `presets.json` file. Not accurate after boot or after using `/edit`                                                                                                                                                                                |
+| ndc          | -1 to 255   | Number of other WLED devices discovered on the network. -1 if Node discovery disabled. (since 0.12.0)                                                                                                                                                                                              |
+| arch         | string      | Name of the platform.                                                                                                                                                                                                                                                                              |
+| core         | string      | Version of the underlying (Arduino core) SDK.                                                                                                                                                                                                                                                      |
+| lwip         | 0, 1, or 2  | Version of LwIP. 1 or 2 on ESP8266, 0 (does not apply) on ESP32. _Deprecated, removal in 0.14.0_                                                                                                                                                                                                   |
+| freeheap     | uint32      | Bytes of heap memory (RAM) currently available. Problematic if <`10k`.                                                                                                                                                                                                                             |
+| uptime       | uint32      | Time since the last boot/reset in seconds.                                                                                                                                                                                                                                                         |
+| opt          | uint16      | Used for debugging purposes only.                                                                                                                                                                                                                                                                  |
+| brand        | string      | The producer/vendor of the light. Always `WLED` for standard installations.                                                                                                                                                                                                                        |
+| product      | string      | The product name. Always `FOSS` for standard installations.                                                                                                                                                                                                                                        |
+| ~~btype~~    | string      | The origin of the build. `src` if a release version is compiled from source, `bin` for an official release image, `dev` for a development build (regardless of src/bin origin) and `exp` for experimental versions. `ogn` if the image is flashed to hardware by the vendor. _Removed as of v0.10_ |
+| mac          | string      | The hexadecimal hardware MAC address of the light, lowercase and without colons.                                                                                                                                                                                                                   |
+| ip           | string      | The IP address of this instance. Empty string if not connected. (since 0.13.0)                                                                                                                                                                                                                     |
 
 #### Per-segment individual LED control
 
@@ -304,13 +310,13 @@ This example applies preset ID 26 for 3 seconds, then preset 20 for 2 seconds, t
 
 Playlist object:
 
-| JSON key | Description
-| --- | --- |
-ps | Array of preset ID integers to be applied in this order.
-dur | Array of time each preset should be kept, in tenths of seconds. If only one integer is supplied, all presets will be kept for that time.Defaults to 10 seconds if not provided.
-transition | Array of time each preset should transition to the next one, in tenths of seconds. If only one integer is supplied, all presets will transition for that time. Defaults to the current transition time if not provided.
-repeat | How many times the entire playlist should cycle before finishing. Set to `0` for an indefinite cycle. Default to indefinite if not provided.
-end | Single preset ID to apply after the playlist finished. Has no effect when an indefinite cycle is set. If not provided, the light will stay on the last preset of the playlist.
+| JSON key   | Description                                                                                                                                                                                                             |
+|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ps         | Array of preset ID integers to be applied in this order.                                                                                                                                                                |
+| dur        | Array of time each preset should be kept, in tenths of seconds. If only one integer is supplied, all presets will be kept for that time.Defaults to 10 seconds if not provided.                                         |
+| transition | Array of time each preset should transition to the next one, in tenths of seconds. If only one integer is supplied, all presets will transition for that time. Defaults to the current transition time if not provided. |
+| repeat     | How many times the entire playlist should cycle before finishing. Set to `0` for an indefinite cycle. Default to indefinite if not provided.                                                                            |
+| end        | Single preset ID to apply after the playlist finished. Has no effect when an indefinite cycle is set. If not provided, the light will stay on the last preset of the playlist.                                          |
 
 #### Light capabilities
 
@@ -319,25 +325,25 @@ The `info.leds.seglc` array can be used to do so on a per-segment level. It cont
 each index corresponds to the segment with that ID.  
 This integer indicates whether a given segment supports (24 bit) RGB colors, an extra (8 bit) white channel and/or adjustable color temperature (CCT):  
 
-| Bit | Capability
-| --- | --- |
-0 | Segment supports RGB color
-1 | Segment supports white channel
-2 | Segment supports color temperature
-3-7 | Reserved (expect any value)
+| Bit | Capability                         |
+|-----|------------------------------------|
+| 0   | Segment supports RGB color         |
+| 1   | Segment supports white channel     |
+| 2   | Segment supports color temperature |
+| 3-7 | Reserved (expect any value)        |
 
 Therefore:  
 
-| `lc` value | Capabilities
-| --- | --- |
-0 | None. Indicates a segment that does not have a bus within its range, e.g. because it is not active.
-1 | Supports RGB
-2 | Supports white channel only
-3 | Supports RGBW
-4 | Supports CCT only, no white channel (unused)
-5 | Supports CCT + RGB, no white channel (unused)
-6 | Supports CCT (including white channel) 
-7 | Supports CCT (including white channel) + RGB
+| `lc` value | Capabilities                                                                                        |
+|------------|-----------------------------------------------------------------------------------------------------|
+| 0          | None. Indicates a segment that does not have a bus within its range, e.g. because it is not active. |
+| 1          | Supports RGB                                                                                        |
+| 2          | Supports white channel only                                                                         |
+| 3          | Supports RGBW                                                                                       |
+| 4          | Supports CCT only, no white channel (unused)                                                        |
+| 5          | Supports CCT + RGB, no white channel (unused)                                                       |
+| 6          | Supports CCT (including white channel)                                                              |
+| 7          | Supports CCT (including white channel) + RGB                                                        |
 
 Note that CCT is controllable per-segment, while RGB color and white channel have 3 color slots each per segment.  
   
@@ -393,29 +399,29 @@ Slider/checkbox labels are comma separated.
 An empty or missing label disables this control.
 `!` specifies the default label is used:
 
-| Parameter | Default tooltip label
-| --- | --- |
-sx | Effect speed
-ix | Effect intensity
-c1 | Custom 1
-c2 | Custom 2
-c3 | Custom 3
-o1 | Option 1
-o2 | Option 2
-o3 | Option 3
+| Parameter | Default tooltip label |
+|-----------|-----------------------|
+| sx        | Effect speed          |
+| ix        | Effect intensity      |
+| c1        | Custom 1              |
+| c2        | Custom 2              |
+| c3        | Custom 3              |
+| o1        | Option 1              |
+| o2        | Option 2              |
+| o3        | Option 3              |
 
 The fallback value if this section is missing is two sliders, Effect speed and Effect intensity.
 
 Examples:  
 
-| Parameter string | Displayed controls
-| --- | --- |
-`<empty>` | No effect parameters
-! | 1 slider: Effect speed
-!,! | 2 sliders: Effect speed + Effect intensity
-!,Phase | 2 sliders: Effect speed + Phase
-,Saturation,,,,Invert | 1 slider (sets `ix` parameter) and 1 checkbox: Saturation + Invert
-,,,,,Random colors | 1 checkbox: Random colors
+| Parameter string      | Displayed controls                                                 |
+|-----------------------|--------------------------------------------------------------------|
+| `<empty>`             | No effect parameters                                               |
+| !                     | 1 slider: Effect speed                                             |
+| !,!                   | 2 sliders: Effect speed + Effect intensity                         |
+| !,Phase               | 2 sliders: Effect speed + Phase                                    |
+| ,Saturation,,,,Invert | 1 slider (sets `ix` parameter) and 1 checkbox: Saturation + Invert |
+| ,,,,,Random colors    | 1 checkbox: Random colors                                          |
 
 ##### Colors
 
@@ -426,13 +432,13 @@ The fallback value if this section is missing is 3 colors: `Fx` + `Bg` + `Cs`.
 
 Examples:  
 
-| Colors string | Displayed controls
-| --- | --- |
-`<empty>` | No color controls
-! | 1 color: Fx
-,! | 1 color: Bg
-!,! | 2 colors: Fx + Bg
-1,2,3 | 3 colors: 1 + 2 + 3
+| Colors string | Displayed controls  |
+|---------------|---------------------|
+| `<empty>`     | No color controls   |
+| !             | 1 color: Fx         |
+| ,!            | 1 color: Bg         |
+| !,!           | 2 colors: Fx + Bg   |
+| 1,2,3         | 3 colors: 1 + 2 + 3 |
 
 ##### Palette
 
@@ -446,14 +452,14 @@ Flags allow filtering for effects with certain characteristics.
 They are a single character each and not comma-separated.
 Currently, the following flags are specified:
 
-| Flag | Effect characteristic
-| --- | --- |
-0 | Effect works well on a single LED. If flag 0 is present, flags 1/2/3 are omitted. (unused)
-1 | Effect is optimized for use on 1D LED strips.
-2 | Effect requires a 2D matrix setup (unless flag 1 is also present)
-3 | Effect requires a 3D cube (unless flags 1 and/or 2 are also present) (unused)
-v | Effect is audio reactive, reacts to amplitude/volume.
-f | Effect is audio reactive, reacts to audio frequency distribution.
+| Flag | Effect characteristic                                                                      |
+|------|--------------------------------------------------------------------------------------------|
+| 0    | Effect works well on a single LED. If flag 0 is present, flags 1/2/3 are omitted. (unused) |
+| 1    | Effect is optimized for use on 1D LED strips.                                              |
+| 2    | Effect requires a 2D matrix setup (unless flag 1 is also present)                          |
+| 3    | Effect requires a 3D cube (unless flags 1 and/or 2 are also present) (unused)              |
+| v    | Effect is audio reactive, reacts to amplitude/volume.                                      |
+| f    | Effect is audio reactive, reacts to audio frequency distribution.                          |
 
 For example, a Flag string of `2v` denotes a volume reactive effect that is to be used on 2D matrices.
 
@@ -492,49 +498,49 @@ refers to a 12 °C temperature measurement in Celsius with the sensor name "Outs
 
 The object may contain the following properties, of which all are optional, except `type`.
 
-| JSON key | Value range | Description
-| --- | --- | --- |
-type | string | The type of the sensor.
-n | string | The name of the sensor. If omitted, the client may generate a suitable name (e.g. "Temperature sensor 1") 
-val | any | The most current sensor reading. May be of any JSON type depending on the type of the sensor, this is a number for all sensor types pre-defined below except for the `"b"` and `"CL"` types and custom type sensors. `null` if the reading is invalid, either due to an error or because the first reading has not yet completed.
-unit | string | An explicit human-readable unit string for the measurement. If omitted, the default for the sensor type is used.
-error | int or string | If present and not `null`,`false`,`0` or an empty string, a sensor error is indicated. May either be an integer error code or an error string.
-tc | number | Seconds of WLED `uptime` when the value last changed substantially. The threshold for a "substantial" change is up to the implementation. This can for example be used to find when a PIR sensor was last activated. 
-tm | number | Seconds of WLED `uptime` when the last reading given by `val` was obtained.
-ts | number | Seconds of WLED `uptime` at the first measurement / start of measurement period. (required for Energy sensor type)
-min | number | Lower bound of possible value range
-max | number | Upper bound of possible value range
-u | number | Absolute uncertainty of the measurement
-model | string | Identification of the sensor hardware used
+| JSON key | Value range   | Description                                                                                                                                                                                                                                                                                                                       |
+|----------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| type     | string        | The type of the sensor.                                                                                                                                                                                                                                                                                                           |
+| n        | string        | The name of the sensor. If omitted, the client may generate a suitable name (e.g. "Temperature sensor 1")                                                                                                                                                                                                                         |
+| val      | any           | The most current sensor reading. May be of any JSON type depending on the type of the sensor, this is a number for all sensor types pre-defined below except for the `"b"` and `"CL"` types and custom type sensors. `null` if the reading is invalid, either due to an error or because the first reading has not yet completed. |
+| unit     | string        | An explicit human-readable unit string for the measurement. If omitted, the default for the sensor type is used.                                                                                                                                                                                                                  |
+| error    | int or string | If present and not `null`,`false`,`0` or an empty string, a sensor error is indicated. May either be an integer error code or an error string.                                                                                                                                                                                    |
+| tc       | number        | Seconds of WLED `uptime` when the value last changed substantially. The threshold for a "substantial" change is up to the implementation. This can for example be used to find when a PIR sensor was last activated.                                                                                                              |
+| tm       | number        | Seconds of WLED `uptime` when the last reading given by `val` was obtained.                                                                                                                                                                                                                                                       |
+| ts       | number        | Seconds of WLED `uptime` at the first measurement / start of measurement period. (required for Energy sensor type)                                                                                                                                                                                                                |
+| min      | number        | Lower bound of possible value range                                                                                                                                                                                                                                                                                               |
+| max      | number        | Upper bound of possible value range                                                                                                                                                                                                                                                                                               |
+| u        | number        | Absolute uncertainty of the measurement                                                                                                                                                                                                                                                                                           |
+| model    | string        | Identification of the sensor hardware used                                                                                                                                                                                                                                                                                        |
 
 #### Sensor types
 
 These are the standardized sensor types that may be implemented by usermods:
 
-| Type ID string | Measurement type | Default unit
-| --- | --- | --- |
-"" (empty string) | Invalid sensor (reserved) | - 
-b | Button/Boolean | true/false
-c | Custom user-defined sensor | -
-q | Electric charge | As
-t | Time | s
-BL| Battery Level | %
-CL| 24-bit RGB color | hex string
-E | Energy (`ts` property required) | J
-I | Electric current | A
-J | Illuminance | lx
-L | Distance | m
-Lp| Sound pressure level | dB
-M | Mass | kg
-N | Number/count | -
-P | Power | W
-Pe| General purpose percentage | %
-PL| Power Level (signal strength) | dBm
-Pr| Pressure | Pa
-R | Electric Resistance | Ohms
-RH| Relative Humidity | %
-T | Temperature | °C
-U | Voltage | V
-(other strings) | Reserved, let us know if you need a new type added | -
+| Type ID string    | Measurement type                                   | Default unit |
+|-------------------|----------------------------------------------------|--------------|
+| "" (empty string) | Invalid sensor (reserved)                          | -            |
+| b                 | Button/Boolean                                     | true/false   |
+| c                 | Custom user-defined sensor                         | -            |
+| q                 | Electric charge                                    | As           |
+| t                 | Time                                               | s            |
+| BL                | Battery Level                                      | %            |
+| CL                | 24-bit RGB color                                   | hex string   |
+| E                 | Energy (`ts` property required)                    | J            |
+| I                 | Electric current                                   | A            |
+| J                 | Illuminance                                        | lx           |
+| L                 | Distance                                           | m            |
+| Lp                | Sound pressure level                               | dB           |
+| M                 | Mass                                               | kg           |
+| N                 | Number/count                                       | -            |
+| P                 | Power                                              | W            |
+| Pe                | General purpose percentage                         | %            |
+| PL                | Power Level (signal strength)                      | dBm          |
+| Pr                | Pressure                                           | Pa           |
+| R                 | Electric Resistance                                | Ohms         |
+| RH                | Relative Humidity                                  | %            |
+| T                 | Temperature                                        | °C           |
+| U                 | Voltage                                            | V            |
+| (other strings)   | Reserved, let us know if you need a new type added | -            |
 
 If a client is only interested in certain sensor types (e.g. Temperature), it may disregard all other sensor objects.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
     - WLED UDP Sync: interfaces/udp-notifier.md
     - UDP Realtime / tpm2.net: interfaces/udp-realtime.md
     - Websocket: interfaces/websocket.md
+    - DDP Realtime: interfaces/ddp.md
   - Advanced:
     - Audio Reactive WLED: advanced/audio-reactive.md
     - Home Automation: advanced/home-automation.md


### PR DESCRIPTION
Added some changes that would have helped me when I was reading through.

Commits:

1. Added documentation for DDP. I know it's not very extensive, but when I was reading through, I didn't think WLED had DDP support because it didn't have a page.
2. Added example JSON API interface library. It's my project, so I'm a little biased, but if I had access to this resource while making it, life would have been so much easier. If someone wants to update the actual docs to include information I had to find by scouring through the WLED source code, then by all means, go ahead. But right now I'm too lazy. Also reformatted Markdown tables. The example library has structures for all JSON structures and documentation for every field.
3. (edit) added "NOT TO BE CONFUSED WITH UDP." in the DDP docs.

I know these changes are pretty low effort, but after all the work I had to go through to figure out this stuff without documentation, I just want other people to be able to use my work instead of going through it again.

