### PR TITLE
Add documentation for expanded dmx segment options

### DIFF
--- a/docs/interfaces/e1.31-dmx.md
+++ b/docs/interfaces/e1.31-dmx.md
@@ -84,23 +84,140 @@ Not a realtime mode & only support 1 universe. Allows setting WLED effect proper
 14 | Green Tertiary
 15 | Blue Tertiary
 
-The `effect option` channel is divided into 128 macro parts to control the various states that a segment can be in. When setting the value on this channel, start with 0 and add the appropriate values in the table listed below to enable each segment option desired.
-
-| Value | Option                         | 2D Only | Notes                                        |
-|-------|--------------------------------|---------|----------------------------------------------|
-| +1    | Reverse Y                      | yes     |                                              |
-| +2    | Mirror Y                       | yes     |                                              |
-| +4    | Transpose                      | yes     |                                              |
-| +0    | Map 1D effects to Pixels       | yes     | Mutually exclusive with other mapped effects |
-| +8    | Map 1D effects to 2D as Bar    | yes     | Mutually exclusive with other mapped effects |
-| +16   | Map 1D effects to 2D as Arc    | yes     | Mutually exclusive with other mapped effects |
-| +24   | Map 1D effects to 2D as Corner | yes     | Mutually exclusive with other mapped effects |
-| +64   | Reverse X                      | No      |                                              |
-| +128  | Mirror X                       | No      |                                              |
-
-For example, sending the value 130 to the effect option channel will enable both Mirror X and Mirror Y (128 + 2).
+The `effect option` channel is divided into 128 macro parts to control the various states that a segment can be in.
 
 Using 2D effect options on a 1D strip has no effect.
+
+| Value    | Reverse | Mirror | 1D to 2D Map (2D only) | Transpose (2D only) | Mirror Y (2D only) | Reverse Y (2D only) |
+|----------|---------|--------|------------------------|---------------------|--------------------|---------------------|
+| 0..1     |         |        | Pixels                 |                     |                    |                     |
+| 2..3     |         |        | Pixels                 |                     |                    | x                   |
+| 4..5     |         |        | Pixels                 |                     | x                  |                     |
+| 6..7     |         |        | Pixels                 |                     | x                  | x                   |
+| 8..9     |         |        | Pixels                 | x                   |                    |                     |
+| 10..11   |         |        | Pixels                 | x                   |                    | x                   |
+| 12..13   |         |        | Pixels                 | x                   | x                  |                     |
+| 14..15   |         |        | Pixels                 | x                   | x                  | x                   |
+| 16..17   |         |        | Bar                    |                     |                    |                     |
+| 18..19   |         |        | Bar                    |                     |                    | x                   |
+| 20..21   |         |        | Bar                    |                     | x                  |                     |
+| 22..23   |         |        | Bar                    |                     | x                  | x                   |
+| 24..25   |         |        | Bar                    | x                   |                    |                     |
+| 26..27   |         |        | Bar                    | x                   |                    | x                   |
+| 28..29   |         |        | Bar                    | x                   | x                  |                     |
+| 30..31   |         |        | Bar                    | x                   | x                  | x                   |
+| 32..33   |         |        | Arc                    |                     |                    |                     |
+| 34..35   |         |        | Arc                    |                     |                    | x                   |
+| 36..37   |         |        | Arc                    |                     | x                  |                     |
+| 38..39   |         |        | Arc                    |                     | x                  | x                   |
+| 40..41   |         |        | Arc                    | x                   |                    |                     |
+| 42..43   |         |        | Arc                    | x                   |                    | x                   |
+| 44..45   |         |        | Arc                    | x                   | x                  |                     |
+| 46..47   |         |        | Arc                    | x                   | x                  | x                   |
+| 48..49   |         |        | Corner                 |                     |                    |                     |
+| 50..51   |         |        | Corner                 |                     |                    | x                   |
+| 52..53   |         |        | Corner                 |                     | x                  |                     |
+| 54..55   |         |        | Corner                 |                     | x                  | x                   |
+| 56..57   |         |        | Corner                 | x                   |                    |                     |
+| 58..59   |         |        | Corner                 | x                   |                    | x                   |
+| 60..61   |         |        | Corner                 | x                   | x                  |                     |
+| 62..63   |         |        | Corner                 | x                   | x                  | x                   |
+| 64..65   | x       |        | Pixels                 |                     |                    |                     |
+| 66..67   | x       |        | Pixels                 |                     |                    | x                   |
+| 68..69   | x       |        | Pixels                 |                     | x                  |                     |
+| 70..71   | x       |        | Pixels                 |                     | x                  | x                   |
+| 72..73   | x       |        | Pixels                 | x                   |                    |                     |
+| 74..75   | x       |        | Pixels                 | x                   |                    | x                   |
+| 76..77   | x       |        | Pixels                 | x                   | x                  |                     |
+| 78..79   | x       |        | Pixels                 | x                   | x                  | x                   |
+| 80..81   | x       |        | Bar                    |                     |                    |                     |
+| 82..83   | x       |        | Bar                    |                     |                    | x                   |
+| 84..85   | x       |        | Bar                    |                     | x                  |                     |
+| 86..87   | x       |        | Bar                    |                     | x                  | x                   |
+| 88..89   | x       |        | Bar                    | x                   |                    |                     |
+| 90..91   | x       |        | Bar                    | x                   |                    | x                   |
+| 92..93   | x       |        | Bar                    | x                   | x                  |                     |
+| 94..95   | x       |        | Bar                    | x                   | x                  | x                   |
+| 96..97   | x       |        | Arc                    |                     |                    |                     |
+| 98..99   | x       |        | Arc                    |                     |                    | x                   |
+| 100..101 | x       |        | Arc                    |                     | x                  |                     |
+| 102..103 | x       |        | Arc                    |                     | x                  | x                   |
+| 104..105 | x       |        | Arc                    | x                   |                    |                     |
+| 106..107 | x       |        | Arc                    | x                   |                    | x                   |
+| 108..109 | x       |        | Arc                    | x                   | x                  |                     |
+| 110..111 | x       |        | Arc                    | x                   | x                  | x                   |
+| 112..113 | x       |        | Corner                 |                     |                    |                     |
+| 114..115 | x       |        | Corner                 |                     |                    | x                   |
+| 116..117 | x       |        | Corner                 |                     | x                  |                     |
+| 118..119 | x       |        | Corner                 |                     | x                  | x                   |
+| 120..121 | x       |        | Corner                 | x                   |                    |                     |
+| 122..123 | x       |        | Corner                 | x                   |                    | x                   |
+| 124..125 | x       |        | Corner                 | x                   | x                  |                     |
+| 126..127 | x       |        | Corner                 | x                   | x                  | x                   |
+| 128..129 |         | x      | Pixels                 |                     |                    |                     |
+| 130..131 |         | x      | Pixels                 |                     |                    | x                   |
+| 132..133 |         | x      | Pixels                 |                     | x                  |                     |
+| 134..135 |         | x      | Pixels                 |                     | x                  | x                   |
+| 136..137 |         | x      | Pixels                 | x                   |                    |                     |
+| 138..139 |         | x      | Pixels                 | x                   |                    | x                   |
+| 140..141 |         | x      | Pixels                 | x                   | x                  |                     |
+| 142..143 |         | x      | Pixels                 | x                   | x                  | x                   |
+| 144..145 |         | x      | Bar                    |                     |                    |                     |
+| 146..147 |         | x      | Bar                    |                     |                    | x                   |
+| 148..149 |         | x      | Bar                    |                     | x                  |                     |
+| 150..151 |         | x      | Bar                    |                     | x                  | x                   |
+| 152..153 |         | x      | Bar                    | x                   |                    |                     |
+| 154..155 |         | x      | Bar                    | x                   |                    | x                   |
+| 156..157 |         | x      | Bar                    | x                   | x                  |                     |
+| 158..159 |         | x      | Bar                    | x                   | x                  | x                   |
+| 160..161 |         | x      | Arc                    |                     |                    |                     |
+| 162..163 |         | x      | Arc                    |                     |                    | x                   |
+| 164..165 |         | x      | Arc                    |                     | x                  |                     |
+| 166..167 |         | x      | Arc                    |                     | x                  | x                   |
+| 168..169 |         | x      | Arc                    | x                   |                    |                     |
+| 170..171 |         | x      | Arc                    | x                   |                    | x                   |
+| 172..173 |         | x      | Arc                    | x                   | x                  |                     |
+| 174..175 |         | x      | Arc                    | x                   | x                  | x                   |
+| 176..177 |         | x      | Corner                 |                     |                    |                     |
+| 178..179 |         | x      | Corner                 |                     |                    | x                   |
+| 180..181 |         | x      | Corner                 |                     | x                  |                     |
+| 182..183 |         | x      | Corner                 |                     | x                  | x                   |
+| 184..185 |         | x      | Corner                 | x                   |                    |                     |
+| 186..187 |         | x      | Corner                 | x                   |                    | x                   |
+| 188..189 |         | x      | Corner                 | x                   | x                  |                     |
+| 190..191 |         | x      | Corner                 | x                   | x                  | x                   |
+| 192..193 | x       | x      | Pixels                 |                     |                    |                     |
+| 194..195 | x       | x      | Pixels                 |                     |                    | x                   |
+| 196..197 | x       | x      | Pixels                 |                     | x                  |                     |
+| 198..199 | x       | x      | Pixels                 |                     | x                  | x                   |
+| 200..201 | x       | x      | Pixels                 | x                   |                    |                     |
+| 202..203 | x       | x      | Pixels                 | x                   |                    | x                   |
+| 204..205 | x       | x      | Pixels                 | x                   | x                  |                     |
+| 206..207 | x       | x      | Pixels                 | x                   | x                  | x                   |
+| 208..209 | x       | x      | Bar                    |                     |                    |                     |
+| 210..211 | x       | x      | Bar                    |                     |                    | x                   |
+| 212..213 | x       | x      | Bar                    |                     | x                  |                     |
+| 214..215 | x       | x      | Bar                    |                     | x                  | x                   |
+| 216..217 | x       | x      | Bar                    | x                   |                    |                     |
+| 218..219 | x       | x      | Bar                    | x                   |                    | x                   |
+| 220..221 | x       | x      | Bar                    | x                   | x                  |                     |
+| 222..223 | x       | x      | Bar                    | x                   | x                  | x                   |
+| 224..225 | x       | x      | Arc                    |                     |                    |                     |
+| 226..227 | x       | x      | Arc                    |                     |                    | x                   |
+| 228..229 | x       | x      | Arc                    |                     | x                  |                     |
+| 230..231 | x       | x      | Arc                    |                     | x                  | x                   |
+| 232..233 | x       | x      | Arc                    | x                   |                    |                     |
+| 234..235 | x       | x      | Arc                    | x                   |                    | x                   |
+| 236..237 | x       | x      | Arc                    | x                   | x                  |                     |
+| 238..239 | x       | x      | Arc                    | x                   | x                  | x                   |
+| 240..241 | x       | x      | Corner                 |                     |                    |                     |
+| 242..243 | x       | x      | Corner                 |                     |                    | x                   |
+| 244..245 | x       | x      | Corner                 |                     | x                  |                     |
+| 246..247 | x       | x      | Corner                 |                     | x                  | x                   |
+| 248..249 | x       | x      | Corner                 | x                   |                    |                     |
+| 250..251 | x       | x      | Corner                 | x                   |                    | x                   |
+| 252..253 | x       | x      | Corner                 | x                   | x                  |                     |
+| 254..255 | x       | x      | Corner                 | x                   | x                  | x                   |
 
 #### Effect + White
 

--- a/docs/interfaces/e1.31-dmx.md
+++ b/docs/interfaces/e1.31-dmx.md
@@ -84,14 +84,23 @@ Not a realtime mode & only support 1 universe. Allows setting WLED effect proper
 14 | Green Tertiary
 15 | Blue Tertiary
 
-The `effect option` channel is divided into 4 macro parts to control _mirror_ and _reverse_ states:
+The `effect option` channel is divided into 128 macro parts to control the various states that a segment can be in. When setting the value on this channel, start with 0 and add the appropriate values in the table listed below to enable each segment option desired.
 
-| value    | mirror   | reverse | |
-|----------|----------|---------|-|
-| 0..63    | false    | false   | **none** |
-| 64..127  | false    | true    | **reverse** |
-| 128..191 | true     | false   | **mirror** |
-| 192..255 | true     | true    | **mirror & reverse** |
+| Value | Option                         | 2D Only | Notes                                        |
+|-------|--------------------------------|---------|----------------------------------------------|
+| +1    | Reverse Y                      | yes     |                                              |
+| +2    | Mirror Y                       | yes     |                                              |
+| +4    | Transpose                      | yes     |                                              |
+| +0    | Map 1D effects to Pixels       | yes     | Mutually exclusive with other mapped effects |
+| +8    | Map 1D effects to 2D as Bar    | yes     | Mutually exclusive with other mapped effects |
+| +16   | Map 1D effects to 2D as Arc    | yes     | Mutually exclusive with other mapped effects |
+| +24   | Map 1D effects to 2D as Corner | yes     | Mutually exclusive with other mapped effects |
+| +64   | Reverse X                      | No      |                                              |
+| +128  | Mirror X                       | No      |                                              |
+
+For example, sending the value 130 to the effect option channel will enable both Mirror X and Mirror Y (128 + 2).
+
+Using 2D effect options on a 1D strip has no effect.
 
 #### Effect + White
 


### PR DESCRIPTION
This PR contains the documentation for sending expanded segment options via e1.31 as implemented in PR https://github.com/Aircoookie/WLED/pull/3616.