### PR TITLE
Add DDP example for TypeScript

### DIFF
--- a/docs/interfaces/ddp.md
+++ b/docs/interfaces/ddp.md
@@ -22,3 +22,4 @@ If you are implementing the protocol to send packets to WLED, do not bother impl
 
  - [ddp-rs](https://github.com/coral/ddp-rs) A Rust library for sending (and even receiving) DDP packets.
  - [LedFX/devices/ddp.py](https://github.com/LedFx/LedFx/blob/main/ledfx/devices/ddp.py) LedFX's implementation for sending DDP packets to WLED
+ - [yeonic/plugins/wled](https://github.com/YeonV/yeonic/blob/main/src/plugins/wled.ts#L51) TypeScript (javascript) implementation - Needs a nodejs like environment


### PR DESCRIPTION
I have successfully created a DDP implementation in TypeScript (javascript) https://github.com/YeonV/yeonic/blob/main/src/plugins/wled.ts#L51

Please note: 
you need to be in some kind of a nodeJs environment  since UDP/DDP is not available in browser environment

works "natively" on:
Desktop (through electron): Windows + Mac + (Linux untested) Mobile (through capacitor): Android + iOS