### PR TITLE
Update settings.md to include 'Clock' setting description.

### DIFF
--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -52,6 +52,7 @@ Each output has the following settings:
 | Setting name | Value Range | Default | Description |
 |---|---|---|---|
 Type (represented by the output's number) | multiple options | WS281x | Select the type of LEDs this output will be controlling
+Clock | multiple options | "Normal" | Select the PWM frequency used when driving analog LEDs <br> Used PWM frequencies for the ESP8266 / ESP32 respectively; <br> Slowest: 293.33 Hz / 6510.33 Hz <br> Slow: 440 Hz / 9765.50 Hz <br> Normal: 880 Hz / 19531 Hz <br> Fast: 1760 Hz / 39062 Hz <br> Fastest: 	2640 Hz / 58593 Hz <br> [*only appears if "Type" is set to a type that supports PWM dimming*]
 Color order | muliple options | "GRB" | Select which order your LEDs process color information (e.g. if your LEDs display red and green swapped, try changing it) [*only appears if "Type" is set to a type that supports color order*]
 Start/Index | integer | cummulative length of all previous outputs | Define which address this output (or its first pixel) should use within WLED's address space [*only editable if "Custom bus start indices" is on*]
 Length | integer | 1 | Define how many pixels are connected to this output [*only appears if "Type" is set to a type that supports multiple pixels*]

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -52,7 +52,7 @@ Each output has the following settings:
 | Setting name | Value Range | Default | Description |
 |---|---|---|---|
 Type (represented by the output's number) | multiple options | WS281x | Select the type of LEDs this output will be controlling
-Clock | multiple options | "Normal" | Select the PWM frequency used when driving analog LEDs <br> Used PWM frequencies for the ESP8266 / ESP32 respectively; <br> Slowest: 293.33 Hz / 6510.33 Hz <br> Slow: 440 Hz / 9765.50 Hz <br> Normal: 880 Hz / 19531 Hz <br> Fast: 1760 Hz / 39062 Hz <br> Fastest: 	2640 Hz / 58593 Hz <br> [*only appears if "Type" is set to a type that supports PWM dimming*]
+Clock | multiple options | "Normal" | Select the PWM or SPI frequency used when driving supported LEDs <br> Used PWM frequencies for the ESP8266 / ESP32, and SPI respectively; <br> Slowest: 293.33 Hz / 6510.33 Hz / 1 MHz <br> Slow: 440 Hz / 9765.50 Hz / 2 MHz <br> Normal: 880 Hz / 19531 Hz / 5 MHz <br> Fast: 1760 Hz / 39062 Hz / 10 MHz <br> Fastest: 2640 Hz / 58593 Hz / 20 MHz <br> [*only appears if "Type" is set to a type that is controlled by PWM or SPI*]
 Color order | muliple options | "GRB" | Select which order your LEDs process color information (e.g. if your LEDs display red and green swapped, try changing it) [*only appears if "Type" is set to a type that supports color order*]
 Start/Index | integer | cummulative length of all previous outputs | Define which address this output (or its first pixel) should use within WLED's address space [*only editable if "Custom bus start indices" is on*]
 Length | integer | 1 | Define how many pixels are connected to this output [*only appears if "Type" is set to a type that supports multiple pixels*]


### PR DESCRIPTION
Adds an entry documenting the function of the 'Clock' setting on the settings page along with actual PWM frequencies used for the ESP8266 and ESP32.

Since there was no description available for what the 'Clock' setting does, I added an entry for it. I found it changes the PWM frequency, and for convenience I also added the actual frequency used for each setting.

I used the calculations used in `set.cpp`:
```
if (type > TYPE_ONOFF && type < 49) {
        switch (freqHz) {
          case 0 : freqHz = WLED_PWM_FREQ/3; break;
          case 1 : freqHz = WLED_PWM_FREQ/2; break;
          default:
          case 2 : freqHz = WLED_PWM_FREQ;   break;
          case 3 : freqHz = WLED_PWM_FREQ*2; break;
          case 4 : freqHz = WLED_PWM_FREQ*3; break;
        }
```
Along with the base frequency as set in `const.h`:
```
#ifdef ESP8266
  #define WLED_PWM_FREQ    880 //PWM frequency proven as good for LEDs
#else
  #define WLED_PWM_FREQ  19531
```
To calculate the used frequencies for each setting.

**However, I am not sure if the 'Clock' setting is available on the ESP32 as well.** On my ESP8266 it is, and I added the calculated frequencies for it in the description field along with the values the ESP32 would use, assuming it also has the 'Clock' setting.

If listing all frequencies in the description is too much info for a single entry, feel free to remove them.