### PR TITLE
Switch the legacy official app for WLED Native

### DIFF
--- a/docs/about/contributors.md
+++ b/docs/about/contributors.md
@@ -15,8 +15,8 @@ adamo made the animated Discord server logo!
 [@blazoncek](https://github.com/blazoncek) makes countless new features and improvements to many parts of WLED!  
 [@debsahu](https://github.com/debsahu) provided the HomeAssistant autodiscovery and a lot of help with PIO!  
 [@ewowi](https://github.com/ewoudwijma) numerous optimizations; 2D, audio and various user mod improvements.  MoonModules maintainer.  
-[@frenck](https://github.com/frenck) made an amazing, stable and feature-packed native integration with HomeAssistant!
-[@Moustachauve](https://github.com/Moustachauve)  added palette visualisation and developped the WLED Native app for Android and iOS!  
+[@frenck](https://github.com/frenck) made an amazing, stable and feature-packed native integration with HomeAssistant!  
+[@Moustachauve](https://github.com/Moustachauve) added palette visualisation and developped the WLED Native app for Android and iOS!  
 [@pbolduc](https://github.com/pbolduc) DDP UDP synchronization, UI improvements and user mods.  
 [@photocromax](https://github.com/photocromax) helped bring the Live visualization feature to life.  
 [@raymiec](https://github.com/raymiec)  is currently working on creating the best clients for Android and iOS!  

--- a/docs/basics/faq.md
+++ b/docs/basics/faq.md
@@ -78,7 +78,7 @@ If you accidentally connected the strip the wrong way (if it has arrows printed 
 
 If you did not enter a static IP, the module will automatically obtain a dynamic IP from the router.
 You can check it in the router configuration or in the settings page, if the Access Point is still enabled.
-An easier way is to use the WLED Android app which features automatic discovery!
+An easier way is to use the WLED Native app which features automatic discovery!
 
 ### The module once was connected, but I can no longer reach it
 
@@ -90,7 +90,7 @@ Else, power-cycle the module manually.
 
 This only works with Apple devices out of the box. You can install Bonjour to make it work in Windows.
 For Android there is no convenient way to achieve it, though you can use apps like "Bonjour search" to find the IP.
-I highly recommend you install the WLED app, which makes automatic discovery easy!
+It is highly recommended that you install the WLED Native app, which makes automatic discovery easy!
 
 ### Is it safe to do a port forwarding to the public internet to control the lights from anywhere?
 
@@ -279,7 +279,9 @@ This will be improved in a future release, so that you will be able to save mult
 
 ### What is the difference between the WLED app and the WLED Native app?
 
-The WLED app is the official app developped by the same people that brought you WLED. WLED Native is an initiative by community member [Moustachauve](https://github.com/Moustachauve) to bring an interface that is closer to the native operating system look of your device and some new features.
+The WLED app was the official app developped by the same people that brought you WLED. WLED Native is an initiative by community member [Moustachauve](https://github.com/Moustachauve) to bring an interface that is closer to the native operating system look of your device and some new features.
+
+The official WLED app is now considered legacy. It is not currently maintained and might not receive any future bug fixes.
 
 WLED Native has a few more features available, like a tablet interface for Android and can keep track of changes to the device IP address better.
 

--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -63,7 +63,7 @@ To connect your WLED module to your home Wifi:
 
 **4.** Reconnect your device to your home's Wifi network.
 
-**5.**  Check the device list in your router's user interface for the IP of the WLED device within your local network. For easy automatic discovery, use the WLED app! Have fun with the WLED software!
+**5.**  Check the device list in your router's user interface for the IP of the WLED device within your local network. For easy automatic discovery, use the WLED Native app! Have fun with the WLED software!
 
 ### Default GPIO Usage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,6 @@ hide:
   <a href="https://wled.discourse.group"><img src="https://img.shields.io/discourse/topics?colorB=blue&label=forum&server=https%3A%2F%2Fwled.discourse.group%2F&style=flat-square"></a>
   <a href="https://discord.gg/QAh7wJHrRM"><img src="https://img.shields.io/discord/473448917040758787.svg?colorB=blue&label=discord&style=flat-square"></a>
   <a href="https://github.com/Aircoookie/WLED"><img src="https://img.shields.io/badge/source-github-blue.svg?style=flat-square"></a>
-  <a href="https://github.com/Aircoookie/WLED-App"><img src="https://img.shields.io/badge/app-wled-blue.svg?style=flat-square"></a>
   <a href="https://gitpod.io/#https://github.com/Aircoookie/WLED"><img src="https://img.shields.io/badge/Gitpod-ready--to--code-blue?style=flat-square&logo=gitpod"></a>
 </p>
   
@@ -41,8 +40,8 @@ A fast and feature-rich implementation of an ESP8266/ESP32 webserver to control 
 
 ## 💡 Supported light control interfaces
 
-- [WLED app](https://github.com/Aircoookie/WLED-App) for [Android](https://play.google.com/store/apps/details?id=com.aircoookie.WLED) and [iOS](https://apps.apple.com/us/app/wled/id1475695033)
-  - Alternatively, WLED Native app made by community member [Moustachauve](https://github.com/Moustachauve)
+- Community driven mobile applications
+  - WLED Native app made by community member [Moustachauve](https://github.com/Moustachauve)
     - For [Android](https://play.google.com/store/apps/details?id=ca.cgagnier.wlednativeandroid) [[Source]((https://github.com/Moustachauve/WLED-Native-Android))]
     - For [iOS](https://apps.apple.com/us/app/wled-native/id6446207239) [[Source]((https://github.com/Moustachauve/WLED-Native-iOS/))]
 - [JSON](/interfaces/json-api) and [HTTP request](/interfaces/http-api) APIs  


### PR DESCRIPTION
This PR marks the legacy WLED app as such, legacy and unmaintained.

This also switch mentions of the WLED app to WLED Native, to encourage people to use it instead since it is actively maintained.