### PR TITLE
Remove "Custom color palettes" as an upcoming feature

### DIFF
--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -8,6 +8,5 @@ hide:
 These are currently on my list of what COULD be implemented, there is no guarantee if and when they will be available!
 
 - Create named playlists of presets
-- Custom color palettes
 - Settings pages overhaul
 - Rework of WiFi connection logic (reconnect after WiFi or power outage)


### PR DESCRIPTION
since they've been a thing since 0.14 🎨

> Beginning in 0.14 up to 10 Custom Palletes [sic] can be uploaded.
https://kno.wled.ge/features/palettes