### PR TITLE
Remove "Create named playlists of presets" as an upcoming feature

### DIFF
--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -7,7 +7,6 @@ hide:
 
 These are currently on my list of what COULD be implemented, there is no guarantee if and when they will be available!
 
-- Create named playlists of presets
 - Custom color palettes
 - Settings pages overhaul
 - Rework of WiFi connection logic (reconnect after WiFi or power outage)


### PR DESCRIPTION
Since they've been a thing since 0.13 🔁

> Playlists supersede Preset cycle in 0.13
https://kno.wled.ge/features/presets/#preset-cycle-up-to-0121

As a related issue, there being a playlist creation GUI could do with being documented, though [the API commands](https://kno.wled.ge/interfaces/json-api/#playlists) are documented.