### PR TITLE
Add python-wled to API client section 

### DIFF
--- a/docs/interfaces/json-api.md
+++ b/docs/interfaces/json-api.md
@@ -31,7 +31,7 @@ You may also obtain those objects individually using the URLs `/json/state` `/js
 The community has created libraries for various programming languages to make working with the WLED JSON API easier.
 
 - [WLED JSON API Library in Rust](https://github.com/paulwrath1223/wled-json-api-library) - Even if you are not using Rust, or don't know how to read Rust, the up-to-date JSON structure is included and documented in this project.
-- [python-wled](https://github.com/frenck/python-wled) - Community-created library for Python.
+- [python-wled](https://github.com/frenck/python-wled) - Python library for the WLED JSON API and the WLED Weboscket API.
 
 ### Setting new values
 

--- a/docs/interfaces/json-api.md
+++ b/docs/interfaces/json-api.md
@@ -30,7 +30,7 @@ You may also obtain those objects individually using the URLs `/json/state` `/js
 
 The community has created libraries for various programming languages to make working with the WLED JSON API easier.
 
-- [WLED JSON API Library in rust](https://github.com/paulwrath1223/wled-json-api-library) - Even if you are not using rust, or don't know how to read rust, the up-to-date JSON structure is included and documented in this project.
+- [WLED JSON API Library in Rust](https://github.com/paulwrath1223/wled-json-api-library) - Even if you are not using Rust, or don't know how to read Rust, the up-to-date JSON structure is included and documented in this project.
 - [python-wled](https://github.com/frenck/python-wled) - Community-created library for Python.
 
 ### Setting new values

--- a/docs/interfaces/json-api.md
+++ b/docs/interfaces/json-api.md
@@ -26,11 +26,12 @@ You may also obtain those objects individually using the URLs `/json/state` `/js
     If called, these will fallback to the Solid effect, in the effects list they have the name `RSVD` or `-`.
     To improve user experience, it is recommended to remove effects with the names `RSVD` or `-` form the UI effect selection.
 
-### Example Library
-[WLED JSON API Library in rust](https://github.com/paulwrath1223/wled-json-api-library).
-Even if you are not using rust, or don't know how to read rust,
-the up-to-date JSON structure is included and documented in this project.
+### Client libraries
 
+The community has created libraries for various programming languages to make working with the WLED JSON API easier.
+
+- [WLED JSON API Library in rust](https://github.com/paulwrath1223/wled-json-api-library) - Even if you are not using rust, or don't know how to read rust, the up-to-date JSON structure is included and documented in this project.
+- [python-wled](https://github.com/frenck/python-wled) - Community-created library for Python.
 
 ### Setting new values
 


### PR DESCRIPTION
Added community-created client libraries for WLED JSON API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Client libraries" section to the JSON API documentation, providing developers with centralized access to Rust and Python client library references for streamlined WLED integration across multiple programming languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->