### PR TITLE
Hub75

### DIFF
--- a/docs/advanced/HUB75.md
+++ b/docs/advanced/HUB75.md
@@ -1,0 +1,65 @@
+---
+title: HUB75 support
+---
+
+WLED now features support for LED matrix panels using the HUB75 format
+
+You can use either a regular ESP32 with a suitable adapter board such as Huidu HD-WF2, [ESP32 Trinity](https://esp32trinity.com/), [MoonHub75](https://github.com/MoonModules/Hardware/tree/main/MOONHUB75), [rorosaurus/esp32-hub75-driver](https://github.com/rorosaurus/esp32-hub75-driver) or the dedicated [Adafruit Matrix Portal S3](https://www.adafruit.com/product/5778)
+
+This support is supplied by the [ESP32-HUB75-MatrixPanel-DMA](https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA?tab=readme-ov-file) library, so see here for more details about supported hardware panels
+
+
+# Setup
+## Required Software Build
+### Adafruit Matrix Portal S3
+Please use the dedicated ESP32-S3_Adafruit_Matrixportal.bin build as this is pre-configured for the pins needed for HUB75 output
+
+### Huidu HD-WF2 ESP32-S3
+* Hold the button down as you use a USB-A to USB-A cable to upload ESP32-S3_HD-WF2.bin
+* See more at https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/issues/433
+
+### Generic ESP32 support
+You must use a build with WLED_ENABLE_HUB75MATRIX defined, for example, ESP32_HUB75.bin. If you do not see Hub75 options in the list of LED types, you are not using the correct build
+
+If you are using a board such as the ESP32 Trinity or other boards wired for the default pinout of the ESP32-HUB75-MatrixPanel-DMA driver, this is selected by default
+
+![display_esp32_wiring_bb](https://github.com/user-attachments/assets/9fd3cf9f-b6b3-42ce-ba52-cea015e95024)
+
+
+If you are using the rorosaurus/esp32-hub75-driver or any other board using the SmartMatrix default pinout then you will need to use the ESP32_HUB75_forum_pinout.bin which has ESP32_FORUM_PINOUT defined
+
+If you are using any other config, you currently need to edit wled00/bus_manager.cpp to add a new elif block and define to your build - it is not possible to set the HUB75 pin config in LED preferences at the moment
+
+### MoonHub75
+This project is a passive adapter board to connect a [Lilygo T7-S3](https://lilygo.cc/products/t7-s3) to a HUB75 Panel. Use ESP32-S3_16MB_opi_HUB75.bin.
+This is the recommended option as it had the most memory, so can handle the highest number of pixels and also supports multiple digital mic options.
+
+
+## Configuration
+### Panel size and chain length
+* Due to limitations in the HUB75 DMA driver, only these panel dimensions are supported:
+  * 32 x 32 (2-scan or 4-scan)
+  * 64 x 32 (2-scan or 4-scan)
+  * 64 x 64 (2-scan or 4-scan)
+  * 128 x 64 (2-scan or 4-scan).
+* Only _one HUB75e port_ is supported.
+* Please chain your panels (panel#1 _OUT_ --> panel#2 _IN_) if you want to control more than one panel.
+* Maximum possible size:
+  * Classic ESP32: the maximum possible size is 128x64 - however WLED might get unstable with this setup. We recommend to use no more than 64x64 on classic esp32.
+  * ESP32-S3 without PSRAM (including Huidu HD-WF2): the maximum possible size is 128x64, however we recommend to use 64x64 because the firmware might get unstable above this size.
+  * ESP32-S3 with PSRAM - octal "opi" PSRAM recommended (including LilyGO T7-S3) : the maximum possible size is 256x64, i.e. 4 chained panels of 64x64 pixels each.
+  * ESP32-S2 is possible, however _not recommended_ due to smaller RAM
+  * ESP32-C3, ESP32-C6 and ESP8266 do not support HUB75
+
+### Setup
+First, you must set the LED output to match the correct Hub75Matrix option for the panel size you are using. The chain length is the number of panels connected. Note: currently only a horizontal chain of panels is supported. ~~You can used 2D setup to configure physical panel positions~~ unfortunately it's not possible to use 2D setup to change the panel layout of chained panels.
+
+Next, you need to go into the 2D Configuration and create a _single_ matrix with the total size of your hub75 setup. e.g a chain of 2 panels with 32x32 pixels each, would be created as a 64x32 matrix in the 2D configuration page
+
+
+## HUB75 Known Problems and Limitations 
+* Maximum possible sizes: see previous section
+* combining HUB75 with other LED types (including virtual leds) was not tested yet - it may or may not work.
+* classic ESP32: using audioreactive microphones (or line-in) causes crashes and wifi instabilities. You can still use UDP sound receive for receiving audio data from another board. Please select "None - network receive only" as DigitalMic type.
+* ESP32-S2: its not possible to use HUB75 and audioreactive at the same time.
+* ESP32-S3: After changing HUB75 options (LED preferences), your display will go black. You need to reboot for driver changes to take effect.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ hide:
   
 # Welcome to my project WLED! ✨
 
-A fast and feature-rich implementation of an ESP32/ESP8266 webserver to control NeoPixel (WS2812B, WS2811, SK6812) LEDs or also SPI based chipsets like the WS2801 and APA102!
+A fast and feature-rich implementation of an ESP32 webserver to control NeoPixel (WS2812B, WS2811, SK6812) LEDs or also SPI based chipsets like the WS2801 & APA102 as well as [HUB75](/advanced/HUB75) video wall panels!
 
 ## ⚙️ Features
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
     - Custom Features: advanced/custom-features.md
     - Community Usermods: advanced/community-usermods.md
     - ESP32 Recovery: advanced/esp32-recovery.md
+    - HUB75: advanced/HUB75.md
     - Mapping: advanced/mapping.md
     - Mixed 2D and 1D Bus: advanced/2d-1d-Mixed-Setup.md
     - Virtual LEDs: advanced/ddp.md


### PR DESCRIPTION
This pull request adds documentation and navigation for new HUB75 LED matrix panel support in WLED. It introduces a comprehensive guide on using HUB75 panels, updates the project introduction to mention HUB75 support, and adds the new documentation page to the navigation menu.

**Documentation for HUB75 support:**

* Added a new page `HUB75.md` detailing setup, configuration, compatible hardware, and known limitations for using HUB75 LED matrix panels with WLED.
* Included HUB75 as a supported LED type in the project introduction in `index.md`.

**Navigation updates:**

* Added the new HUB75 documentation page to the advanced section of the documentation navigation in `mkdocs.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive HUB75 LED matrix panel documentation with ESP32 hardware recommendations, supported configurations, firmware build requirements, setup procedures, and documented limitations for proper implementation.
  * Updated documentation homepage to accurately reflect current ESP32 platform scope.
  * Added HUB75 advanced section to primary documentation navigation structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED-Docs/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->