### PR TITLE
More usermod doc tweaks

### DIFF
--- a/docs/advanced/community-usermods.md
+++ b/docs/advanced/community-usermods.md
@@ -22,5 +22,5 @@ Platforms: `esp32`, `esp8266`, or `both`.
 
 | Name | Description | Author | Platforms | Notes |
 |---|---|---|---|---|
-| [wled-usermod-example](https://github.com/wled/wled-usermod-example) | Annotated template — fork this to start your own usermod | @wled | both | Official starting point |
+| [wled-usermod-example](https://github.com/wled/wled-usermod-example) | Annotated template — use as template to start your own usermod | @wled | both | Official starting point |
 | [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx) | Community effects usermod — add your own effects here or use as a template | @wled | both | Ships with WLED; enable with `custom_usermods = user_fx` |

--- a/docs/advanced/community-usermods.md
+++ b/docs/advanced/community-usermods.md
@@ -6,9 +6,34 @@ This page is an index of usermods written by the WLED community. Entries are mai
 
 To help people find your usermod even before it appears here, tag your GitHub repository with the [`wled-usermod`](https://github.com/topics/wled-usermod) topic.
 
-## Adding your usermod
+!!! warning "Community content — use at your own risk"
+    The usermods listed below are created and maintained by community members, **not** the WLED development team.
+    **The WLED project does not review, test, endorse, or provide support for any of these modules.**
 
-Open a pull request to [WLED-Docs](https://github.com/wled/WLED-Docs) adding a row to the table below. One row, one PR.
+    Usermods are native C++ code compiled directly into your WLED firmware. A usermod runs with
+    **full, unrestricted access** to your device's hardware, network, and memory — there is no
+    sandbox or permission system to limit what it can do. Before installing a third-party build:
+
+    - **Read the source code** (or have someone you trust read it) before flashing.
+    - Be aware that a malicious or poorly written usermod could expose your network, **brick your
+      device**, or behave in ways its description does not mention.
+    - Only flash firmware from sources you trust. Prefer builds you compile yourself from
+      reviewed source code over pre-compiled binaries distributed by strangers.
+
+    The WLED project cannot verify the safety or quality of community usermods.
+    **You are solely responsible for any third-party code you choose to run on your devices.**
+
+## Index
+
+| Name | Description | Author | Platforms | Notes |
+|---|---|---|---|---|
+| [wled-usermod-example](https://github.com/wled/wled-usermod-example) | Annotated template — use as template to start your own usermod | @wled | both | Official starting point |
+| [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx) | Community effects usermod — add your own effects here or use as a template | @wled | both | Ships with WLED; enable with `custom_usermods = user_fx` |
+
+
+## Adding your usermod to the list
+
+Open a pull request to [WLED-Docs](https://github.com/wled/WLED-Docs) adding a row to the table above. 
 
 Use this format:
 
@@ -17,10 +42,3 @@ Use this format:
 ```
 
 Platforms: `esp32`, `esp8266`, or `both`.
-
-## Index
-
-| Name | Description | Author | Platforms | Notes |
-|---|---|---|---|---|
-| [wled-usermod-example](https://github.com/wled/wled-usermod-example) | Annotated template — use as template to start your own usermod | @wled | both | Official starting point |
-| [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx) | Community effects usermod — add your own effects here or use as a template | @wled | both | Ships with WLED; enable with `custom_usermods = user_fx` |

--- a/docs/advanced/community-usermods.md
+++ b/docs/advanced/community-usermods.md
@@ -25,10 +25,10 @@ To help people find your usermod even before it appears here, tag your GitHub re
 
 ## Index
 
-| Name | Description | Author | Platforms | Notes |
-|---|---|---|---|---|
-| [wled-usermod-example](https://github.com/wled/wled-usermod-example) | Annotated template — use as template to start your own usermod | @wled | both | Official starting point |
-| [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx) | Community effects usermod — add your own effects here or use as a template | @wled | both | Ships with WLED; enable with `custom_usermods = user_fx` |
+| Name | Description | Author | Platforms | License | Notes |
+|---|---|---|---|---|---|
+| [wled-usermod-example](https://github.com/wled/wled-usermod-example) | Annotated template — use as template to start your own usermod | @wled | both | EUPL | Official starting point |
+| [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx) | Community effects usermod — add your own effects here or use as a template | @wled | both | EUPL | Ships with WLED; enable with `custom_usermods = user_fx` |
 
 
 ## Adding your usermod to the list
@@ -38,7 +38,7 @@ Open a pull request to [WLED-Docs](https://github.com/wled/WLED-Docs) adding a r
 Use this format:
 
 ```markdown
-| [Name](https://github.com/you/your-usermod) | Short description | @yourname | esp32 |  |
+| [Name](https://github.com/you/your-usermod) | Short description | @yourname | esp32 | MIT |  |
 ```
 
 Platforms: `esp32`, `esp8266`, or `both`.

--- a/docs/advanced/custom-features.md
+++ b/docs/advanced/custom-features.md
@@ -47,18 +47,18 @@ custom_usermods =
 
 The recommended approach is to keep your usermod in its own repository, separate from the WLED source tree. This lets you version and share it independently, and reference it from any WLED build without copying files.
 
-#### 1. Fork the example repository
+#### 1. Create a repository from the template
 
-Fork [wled/wled-usermod-example](https://github.com/wled/wled-usermod-example) on GitHub. It contains a minimal `library.json` and a fully annotated example implementation — everything you need to get started. Rename the files and class to something descriptive, then add your code.
+On GitHub, open [wled/wled-usermod-example](https://github.com/wled/wled-usermod-example) and click **Use this template → Create a new repository**. This gives you a clean, independent repository pre-loaded with a minimal `library.json` and a fully annotated example implementation. Rename the files and class to something descriptive, then add your code.
 
 #### 2. Reference it locally during development
 
-Clone your fork somewhere convenient — alongside your WLED checkout works well, since both projects can then be open in the same VS Code session:
+Clone your new repository somewhere convenient — alongside your WLED checkout works well, since both projects can then be open in the same VS Code session:
 
 ```text
 ~/projects/
   WLED/                   ← the WLED source
-  my-wled-usermod/        ← your fork
+  my-wled-usermod/        ← your repository
     library.json
     my_usermod.cpp
 ```

--- a/docs/advanced/custom-features.md
+++ b/docs/advanced/custom-features.md
@@ -73,7 +73,7 @@ custom_usermods =
   symlink:///home/you/projects/my-wled-usermod
 ```
 
-On Windows, use the `symlink:///C:/Users/you/...` form with forward slashes: `symlink:///C:/Users/you/projects/my-wled-usermod`.
+On Windows, use the `symlink://C:/Users/you/...` form with forward slashes: `symlink://C:/Users/you/projects/my-wled-usermod`.
 
 PlatformIO will pick up your local changes on each build, and you can edit the usermod and WLED side-by-side without switching projects.
 

--- a/docs/advanced/custom-features.md
+++ b/docs/advanced/custom-features.md
@@ -63,17 +63,17 @@ Clone your new repository somewhere convenient — alongside your WLED checkout 
     my_usermod.cpp
 ```
 
-In `platformio_override.ini`, point `custom_usermods` at the local clone using a `file://` URL:
+In `platformio_override.ini`, point `custom_usermods` at the local clone using a `symlink://` URL:
 
 ```ini
 [env:esp32dev_my_usermod]
 extends = env:esp32dev
 custom_usermods =
   ${env:esp32dev.custom_usermods}
-  file:///home/you/projects/my-wled-usermod
+  symlink:///home/you/projects/my-wled-usermod
 ```
 
-On Windows, use the `file:///C:/Users/you/...` form with forward slashes: `file:///C:/Users/you/projects/my-wled-usermod`.
+On Windows, use the `symlink:///C:/Users/you/...` form with forward slashes: `symlink:///C:/Users/you/projects/my-wled-usermod`.
 
 PlatformIO will pick up your local changes on each build, and you can edit the usermod and WLED side-by-side without switching projects.
 


### PR DESCRIPTION
- Fix documentation for using example usermod as a template.  Fork-based workflows don't work on GitHub.
- Fix PlatformIO syntax for local usermod checkouts, (symlink://, not file://).  I really should've caught this one earlier!
- Add warning box to community usermods page
- Add license column to community usermods page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a prominent “Community content — use at your own risk” warning about unreviewed third‑party usermods and potential risks
  * Updated the usermod index/table to include a License column and adjusted example rows for clarity
  * Revised contribution and local development guidance to simplify setup and include repository-template and symlink-based instructions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->