### PR TITLE
Remove broken link to relay tutorial

### DIFF
--- a/docs/features/relay-control.md
+++ b/docs/features/relay-control.md
@@ -11,8 +11,6 @@ Previously, GPIO12 (Pin D6 on many devices) was set as the default and is confir
 
 When you decide that you want WLED to control a relay, make sure you buy a suitable relay board. Check what voltage you can supply from your controller to relay (available 3.3V or 5V pin or different voltage from external power source), and make sure the relay can be controlled by voltage level your board is providing  (3.3V CMOS, 5V TTL). Note, some relays come with a jumper that lets you configure whether the relay switches at high or low level of signal, giving you maximum flexibility.
 
-[This page](https://www.geekering.com/?p=187) gives a clear description using a light bulb instead of a LED strip. And instead of the D1 mentioned there, with WLED, you use the pin you set.
-
 The default WLED behavior is to turn the relay pin on (high) when the LEDs are on and off (low) when the LEDs are off. This can be changed in the LED Preferences page. Many relays are powered when the signal is LOW. See [this thread](https://github.com/wled/WLED/issues/631#issuecomment-605512524).
 
 Sometimes people ask whether they can control more than one relay through WLED, including controlling this all via Alexa. Controlling an extra relay separately from the RGB lights is not something WLED is designed to do, however you can modify the code to add that functionality. For that, make sure you can compile WLED from source unmodified first. Then, change #define ESPALEXA_MAXDEVICES 1 in line 71 of the wled.h file to 2. After that, just follow the API documentation on https://github.com/Aircoookie/Espalexa to add a new EspalexaDevice to the alexa.cpp file


### PR DESCRIPTION
Removed a link to a tutorial on the geekering.com website, which no longer exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a reference to an external relay wiring example from the relay control guide.
  * Clarified guidance so the documented relay setup aligns with the configured pin behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->