### PR TITLE
Clean up home automation page

### DIFF
--- a/docs/advanced/home-automation.md
+++ b/docs/advanced/home-automation.md
@@ -5,8 +5,8 @@ hide:
   # - toc
 ---
 
-It is possible to interface WLED with home automation systems and other 3rd party software.
-You can use any API WLED provides (JSON, HTTP, UDP, MQTT), JSON is preferred. This page is intended for sample code and configs others use to control WLED from various 3rd party software:
+It is possible to interface WLED with home automation systems and other 3rd-party software.
+You can use any API WLED provides (JSON, HTTP, UDP, MQTT); JSON is preferred. This page is intended for sample code and configs others use to control WLED from various 3rd-party software.
 
 [HomeAssistant and NodeRED flows](https://github.com/Snipercaine/WLED-HomeAssistant)
 

--- a/docs/advanced/home-automation.md
+++ b/docs/advanced/home-automation.md
@@ -8,11 +8,6 @@ hide:
 It is possible to interface WLED with home automation systems and other 3rd-party software.
 You can use any API WLED provides (JSON, HTTP, UDP, MQTT); JSON is preferred. This page is intended for sample code and configs others use to control WLED from various 3rd-party software.
 
-[HomeAssistant and NodeRED flows](https://github.com/Snipercaine/WLED-HomeAssistant)
-
-## Domoticz:
-Please see [here](https://github.com/frustreermeneer/domoticz-wled-plugin)!
-
 ## Home Assistant
 
 ### Using the native integration
@@ -139,8 +134,6 @@ In case you want to configure the device manually:
       ]
     }
     ```
-## Indigo Domotics:
-Please see [here](https://www.indigodomo.com/pluginstore/214/)!
 
 ## openHAB: 
 
@@ -148,5 +141,13 @@ In openHAB 3 based environments you are able to use the native [openHAB WLED Bin
 
 For older openHAB (2.5.x) environmantes the connection can be configured via MQTT broker & Openhab MQTT Binding (2.5x) with configuration files 
 Please find the details [here](https://community.openhab.org/t/wled-control-without-the-binding/101120)
+
+## Other
+
+- [HomeAssistant and NodeRED flows](https://github.com/Snipercaine/WLED-HomeAssistant)
+
+- [Domoticz](https://github.com/frustreermeneer/domoticz-wled-plugin)
+
+- [Indigo Domotics](https://www.indigodomo.com/pluginstore/214/)!
 
 

--- a/docs/advanced/home-automation.md
+++ b/docs/advanced/home-automation.md
@@ -135,12 +135,12 @@ In case you want to configure the device manually:
     }
     ```
 
-## openHAB: 
+## openHAB
 
-In openHAB 3 based environments you are able to use the native [openHAB WLED Binding](https://www.openhab.org/addons/bindings/wled/), which also supports discovery of your WLED devices.
+In openHAB 3-based environments, you are able to use the native [openHAB WLED Binding](https://www.openhab.org/addons/bindings/wled/), which also supports discovery of your WLED devices.
 
-For older openHAB (2.5.x) environmantes the connection can be configured via MQTT broker & Openhab MQTT Binding (2.5x) with configuration files 
-Please find the details [here](https://community.openhab.org/t/wled-control-without-the-binding/101120)
+For older openHAB (2.5.x) environments, the connection can be configured via MQTT broker & Openhab MQTT Binding (2.5x) with configuration files.
+Please find the details [here](https://community.openhab.org/t/wled-control-without-the-binding/101120).
 
 ## Other
 

--- a/docs/advanced/home-automation.md
+++ b/docs/advanced/home-automation.md
@@ -148,6 +148,6 @@ Please find the details [here](https://community.openhab.org/t/wled-control-with
 
 - [Domoticz](https://github.com/frustreermeneer/domoticz-wled-plugin)
 
-- [Indigo Domotics](https://www.indigodomo.com/pluginstore/214/)!
+- [Indigo Domotics](https://www.indigodomo.com/pluginstore/214/)
 
 


### PR DESCRIPTION
Fix grammar; improve organization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved the Home Automation guide’s introductory wording and cleaned up minor punctuation/spacing.
  * Reorganized the post-MQTT resources into a clearer structure, including a dedicated openHAB section and a new “Other” section for related setup links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->