### PR TITLE
community-usermods: add Word Clock FX

### DIFF
--- a/docs/advanced/community-usermods.md
+++ b/docs/advanced/community-usermods.md
@@ -29,6 +29,7 @@ To help people find your usermod even before it appears here, tag your GitHub re
 |---|---|---|---|---|---|
 | [wled-usermod-example](https://github.com/wled/wled-usermod-example) | Annotated template — use as template to start your own usermod | @wled | both | EUPL | Official starting point |
 | [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx) | Community effects usermod — add your own effects here or use as a template | @wled | both | EUPL | Ships with WLED; enable with `custom_usermods = user_fx` |
+| [Word Clock FX](https://github.com/AustinSaintAubin/wled-usermod-word-clock-fx-16x16) | 16×16 English word-clock as a first-class WLED effect, with Open-Meteo weather words/presets and corner-button LEDs | @AustinSaintAubin | esp32 | MIT |  |
 
 
 ## Adding your usermod to the list


### PR DESCRIPTION
Adds a row to the Community Usermods index for **Word Clock FX**, a 16×16 English word-clock as a first-class WLED effect (Open-Meteo weather words/presets + corner-button LEDs).

- Repo: https://github.com/AustinSaintAubin/wled-usermod-word-clock-fx-16x16 (MIT, esp32)
- Tagged with the `wled-usermod` topic.
- Consumed out-of-tree via `custom_usermods = https://github.com/AustinSaintAubin/wled-usermod-word-clock-fx-16x16.git#main` (verified building against WLED).

Context: originally proposed in-tree as wled/WLED#5708; per maintainer feedback, publishing out-of-tree and listing it here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community usermod entry for **Word Clock FX** in the usermods index.
  * The listing now includes the project description, platform, license, author, and notes for easier discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->