### PR TITLE
community-usermods: add Sensors I2C

### DIFF
--- a/docs/advanced/community-usermods.md
+++ b/docs/advanced/community-usermods.md
@@ -30,6 +30,7 @@ To help people find your usermod even before it appears here, tag your GitHub re
 | [wled-usermod-example](https://github.com/wled/wled-usermod-example) | Annotated template — use as template to start your own usermod | @wled | both | EUPL | Official starting point |
 | [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx) | Community effects usermod — add your own effects here or use as a template | @wled | both | EUPL | Ships with WLED; enable with `custom_usermods = user_fx` |
 | [Word Clock FX](https://github.com/AustinSaintAubin/wled-usermod-word-clock-fx-16x16) | 16×16 English word-clock as a first-class WLED effect, with Open-Meteo weather words/presets and corner-button LEDs | @AustinSaintAubin | esp32 | MIT |  |
+| [Sensors I2C](https://github.com/AustinSaintAubin/wled-usermod-sensors-i2c) | Combined I²C environmental sensors (HTU21D temp/humidity, BMP180 pressure, BH1750 lux); can drive WLED auto-brightness, optional MQTT/HA | @AustinSaintAubin | esp32 | MIT |  |
 
 
 ## Adding your usermod to the list


### PR DESCRIPTION
Adds an index row for a community out-of-tree usermod: **[Sensors I2C](https://github.com/AustinSaintAubin/wled-usermod-sensors-i2c)**.

It supports the common 3-in-1 I²C environmental breakout — **HTU21D** (temp/humidity), **BMP180** (temp/pressure), **BH1750FVI** (lux) — reports to the Info page / `/json` and optional MQTT/Home Assistant, and can drive WLED's overall brightness from ambient light.

- Repo is public, tagged with the `wled-usermod` topic, MIT licensed, release `v1.0.0`.
- Self-contained (no `wled00/` changes); consumed via the git-URL `custom_usermods` mechanism. Verified building into WLED for ESP32.

Single-line addition to the community usermods table, following the documented format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Community Usermod entry for **Sensors I2C** on **esp32**.
  * The listing includes supported I²C environmental sensors, licensing details, and notes about auto-brightness plus optional MQTT/Home Assistant integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->