### PR TITLE
Add PowerManager usermod to the community usermods index

### DIFF
--- a/docs/advanced/community-usermods.md
+++ b/docs/advanced/community-usermods.md
@@ -30,6 +30,7 @@ To help people find your usermod even before it appears here, tag your GitHub re
 | [wled-usermod-example](https://github.com/wled/wled-usermod-example) | Annotated template — use as template to start your own usermod | @wled | both | EUPL | Official starting point |
 | [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx) | Community effects usermod — add your own effects here or use as a template | @wled | both | EUPL | Ships with WLED; enable with `custom_usermods = user_fx` |
 | [Word Clock FX](https://github.com/AustinSaintAubin/wled-usermod-word-clock-fx-16x16) | 16×16 English word-clock as a first-class WLED effect, with Open-Meteo weather words/presets and corner-button LEDs | @AustinSaintAubin | esp32 | MIT |  |
+| [PowerManager](https://github.com/intermittech/wled-usermod-powermanager) | Per-segment power switching: relay/MOSFET outputs follow segment on/off, with anti-flash power sequencing, PSU stabilization and a Master AC relay | @intermittech | esp32 | EUPL | Grown from the built-in multi_relay usermod |
 
 
 ## Adding your usermod to the list


### PR DESCRIPTION
Adds the **PowerManager** usermod to the community usermods index, following the row format documented on the page.

**Repository:** https://github.com/intermittech/wled-usermod-powermanager (tagged with the `wled-usermod` topic)

PowerManager provides per-segment power switching for LED installations: named relay/MOSFET outputs (direct GPIO or PCF8574/AW9523 I2C expanders) follow their segment's on/off state, with anti-flash power sequencing, PSU stabilization and a dedicated Master AC relay. It grew out of the built-in `multi_relay` usermod (heritage credited in the repo; settings migrate automatically) and is licensed EUPL-1.2 like WLED itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the PowerManager community usermod to the advanced usermods index.
  * Included its features, author, supported platform, license, and GitHub link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->