### PR TITLE
Add CONTRIBUTING and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at dev.aircoookie@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Thanks for Improving the WLED Docs!
+
+This is the official [WLED](https://github.com/wled/WLED) user documentation, published at [kno.wled.ge](https://kno.wled.ge) with [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/). Every fix and addition helps other users, so thank you! 😊
+
+## The Easiest Way to Start
+
+Click the pencil icon at the top right of any page on [kno.wled.ge](https://kno.wled.ge), or open a Markdown file here on GitHub and click the pencil. Make your edit, choose "Commit changes", and GitHub creates a pull request from your fork automatically.
+
+## Making a Bigger Change
+
+For larger edits, work from a branch in your own fork rather than your `main` branch. That way you can keep updating the PR while `main` stays clean.
+
+1. Fork this repository and create a branch.
+2. Edit the Markdown files under `docs/`.
+3. Preview locally (see below).
+4. Open a pull request against the `main` branch.
+
+Please keep each PR focused on one topic, and add a short description of what you changed and why. No need to write an essay.
+
+## Writing Style
+
+We're harmonizing the docs for readability, so please follow the conventions in [AGENTS.md](AGENTS.md). The short version:
+
+- Write in **English**, in an informal, friendly tone. Contractions are welcome.
+- Use **Title Case** for the page title and section headings.
+- Keep sentences short and simple, so non-native English speakers can follow easily.
+- Be concise: drop filler like "it is worth noting that" or "simply".
+- Prefer plain words: "use" over "leverage", "feature" over "functionality".
+- Only claim what the evidence supports (don't write "proves" when it "suggests").
+- Use Material admonitions (`!!! info`, `!!! tip`, `!!! warning`, `!!! danger`) for callouts.
+- Store images in `docs/assets/images/content/`, not on external hosts.
+- Use root-relative internal links without the `.md` extension, e.g. `[Segments](/features/segments)`.
+
+The full [PR review checklist](AGENTS.md#pr-review-checklist) in AGENTS.md is what maintainers check against.
+
+## Adding a New Page
+
+A new page won't appear in the site until it's registered in the `nav:` section of `mkdocs.yml`. See the [README](README.md) for a step-by-step example. Indentation in `mkdocs.yml` matters.
+
+## Previewing Locally
+
+**Docker (recommended):**
+
+```bash
+docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
+```
+
+**Python/pip:**
+
+```bash
+pip install mkdocs-material
+mkdocs serve
+```
+
+Then open <http://localhost:8000>.
+
+## Deployment
+
+You don't need to deploy anything. Merges to `main` trigger a GitHub Actions workflow that builds the site and publishes it to [kno.wled.ge](https://kno.wled.ge) automatically.
+
+## Code of Conduct
+
+Please be kind. This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Please keep each PR focused on one topic, and add a short description of what yo
 
 ## Writing Style
 
-We're harmonizing the docs for readability, so please follow the conventions in [AGENTS.md](AGENTS.md). The short version:
+We're harmonizing the docs for readability, so please follow the conventions in [AGENTS.md](AGENTS.md) (our contributor and AI-agent instructions). The short version:
 
 - Write in **English**, in an informal, friendly tone. Contractions are welcome.
 - Use **Title Case** for the page title and section headings.


### PR DESCRIPTION
The docs repo has no `CONTRIBUTING.md` or `CODE_OF_CONDUCT.md`, though the main WLED repo has both.

- **`CONTRIBUTING.md`** — a short, friendly guide (how to edit, PR from a fork branch, local preview, auto-deploy). It points to the existing `AGENTS.md` for the writing-style rules and PR checklist rather than duplicating them.
- **`CODE_OF_CONDUCT.md`** — the same Contributor Covenant v1.4 the main WLED repo uses, for consistency (same contact address).

No changes to `AGENTS.md` or any existing pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Code of Conduct outlining expected behavior, reporting procedures, and enforcement guidelines.
  * Added contributor guidance for making WLED documentation updates, including pull request expectations, writing standards, local preview steps, navigation integration, and publishing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->