### PR TITLE
Add STYLE_GUIDE.md surfacing the writing conventions from AGENTS.md

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,19 @@
+# WLED-Docs Style Guide
+
+The complete, authoritative writing and formatting rules live in **[AGENTS.md](AGENTS.md)** — it is the single source of truth for both human contributors and AI agents, so this file stays a pointer rather than a copy (that way the rules never drift out of sync).
+
+At a glance, the docs should be:
+
+- **English**, in an **informal, friendly** tone. Contractions are welcome. 😊
+- **Title Case** for the page title and every section heading (articles and short prepositions stay lowercase).
+- **Simple and clear** — short sentences, common words, no unexplained jargon — so non-native English speakers can follow easily.
+- **Concise** — cut filler like "it is worth noting that" or "simply". Prefer "use" over "leverage", "feature" over "functionality".
+- **Calibrated** — match the verb to the evidence (don't write "proves" when it only "suggests").
+
+Formatting essentials:
+
+- Use Material admonitions (`!!! info`, `!!! tip`, `!!! warning`, `!!! danger`) for callouts.
+- Store images in `docs/assets/images/content/`, never on external hosts.
+- Use root-relative internal links without the `.md` extension, e.g. `[Segments](/features/segments)`.
+
+For the full ruleset and the PR review checklist, see **[AGENTS.md](AGENTS.md)**.


### PR DESCRIPTION
The docs' writing and formatting rules live in `AGENTS.md`, but that file isn't surfaced by GitHub's community profile and reads as AI-agent instructions, so human contributors may not find it.

This adds a top-level `STYLE_GUIDE.md` that:
- Points to `AGENTS.md` as the single source of truth (a pointer, not a copy, so the rules can't drift out of sync).
- Lists the at-a-glance essentials: Title Case headings, informal/friendly tone, concise wording, calibrated claims, Material admonitions, local images, and root-relative links without `.md`.

Intended to support the ongoing effort to harmonize writing style across the docs by making those conventions easy to discover. No changes to `AGENTS.md` or any existing pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a concise writing and formatting guide covering tone, headings, clarity, claims, admonitions, images, and internal links.
  * Included a reference to the authoritative documentation standards and review checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->