### PR TITLE
Fix runaway code fence on the Compiling WLED page

### DIFF
--- a/docs/advanced/compiling-wled.md
+++ b/docs/advanced/compiling-wled.md
@@ -64,11 +64,11 @@ Once you've confirmed VSCode with Platformio is set up correctly, you can add/de
  1. Copy and paste the contents of `platformio_override.ini.sample` into a new file called `platformio_override.ini`. Make sure `platformio_override.ini` is in the same folder as `platformio.ini`.
  2. Replace the line `default_envs = WLED_tasmota_1M` with the line you uncommented in `platformio.ini` in the previous steps (from Compilation guide (PlatformIO)). Example: `default_envs = d1_mini`
  3. In `platformio.ini` scroll down until you see
-```
- #--------------------
- # WLED BUILDS
- #--------------------
- ```
+    ```
+    #--------------------
+    # WLED BUILDS
+    #--------------------
+    ```
  4. Find the section that matches the build environment you selected in previous steps. Example: `[env:d1_mini]`
  5. Select the whole section (including the first line in brackets [ ] ), and copy and paste it into `platformio_override.ini` overwriting the build environment section that was already there.
  6. Add a new line under the the line that starts with `build_flags =`

--- a/docs/advanced/compiling-wled.md
+++ b/docs/advanced/compiling-wled.md
@@ -64,7 +64,7 @@ Once you've confirmed VSCode with Platformio is set up correctly, you can add/de
  1. Copy and paste the contents of `platformio_override.ini.sample` into a new file called `platformio_override.ini`. Make sure `platformio_override.ini` is in the same folder as `platformio.ini`.
  2. Replace the line `default_envs = WLED_tasmota_1M` with the line you uncommented in `platformio.ini` in the previous steps (from Compilation guide (PlatformIO)). Example: `default_envs = d1_mini`
  3. In `platformio.ini` scroll down until you see
-    ```
+    ```ini
     #--------------------
     # WLED BUILDS
     #--------------------


### PR DESCRIPTION
The "WLED BUILDS" code fence in step 3 of [Making a custom environment](https://kno.wled.ge/advanced/compiling-wled/#making-a-custom-environment) opens at column 0 while the list around it is indented one space, so the closing fence never matches. Everything after it (steps 4 to 8 and the Adding usermods example) currently renders inside one big code block on the live page.

This indents the fence to the list's content level, so it stays a small snippet inside step 3 and the rest of the section renders normally again. Verified with a local mkdocs build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of the custom environment compilation instructions.
  * Clearly separated the “WLED BUILDS” marker text in a code block for easier copying and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->