### PR TITLE
Fix external links not opening in new tabs after instant navigation

### DIFF
--- a/docs/assets/js/newtab.js
+++ b/docs/assets/js/newtab.js
@@ -1,12 +1,20 @@
-(function() {
+function decorateLinks() {
   var links = document.links;
   for (var i = 0, linksLength = links.length; i < linksLength; i++) {
     if (links[i].hostname != window.location.hostname) {
       links[i].target = "_blank";
       links[i].setAttribute("rel", "noopener noreferrer");
-      links[i].className += " externalLink";
+      links[i].classList.add("externalLink");
     } else {
-      links[i].className += " localLink";    
+      links[i].classList.add("localLink");
     }
   }
-})();
+}
+
+/* With navigation.instant, Material swaps page content without a full
+   reload; document$ emits on every page change, including the first. */
+if (window.document$) {
+  window.document$.subscribe(decorateLinks);
+} else {
+  decorateLinks();
+}


### PR DESCRIPTION
`newtab.js` runs once at initial page load. With `navigation.instant` enabled, Material swaps page content without a full reload, so external links only get `target="_blank"` and `rel="noopener noreferrer"` on the first page a visitor lands on. After any in-site navigation, external links open in the same tab.

To reproduce: open any page on [kno.wled.ge](https://kno.wled.ge), click a sidebar link, then click an external link (for example a GitHub link). It replaces the docs tab instead of opening a new one.

This subscribes the link decoration to Material's `document$` observable, which emits on every page change including the first. `classList.add` replaces the string concatenation so classes aren't duplicated when the landing page is decorated again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved handling and styling of external and local links.
  * External links now open in a new tab with enhanced security protections.
  * Link behavior remains consistent when navigating through dynamically updated documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->