### PR TITLE
Add mermaid diagram support

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,11 @@ markdown_extensions:
   - admonition
   - attr_list
   - pymdownx.highlight
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.details
   - pymdownx.tilde
 extra:


### PR DESCRIPTION
﻿This registers the `mermaid` custom fence with pymdownx.superfences, so fenced ```mermaid blocks render as native diagrams. Material handles the rest: it lazy-loads the renderer only when a page actually contains a diagram and themes the output to match the active light/dark palette, so there are no new assets, scripts, or styles to maintain.

This PR only adds the capability. No diagrams are added yet; a follow-up PR will introduce them where they genuinely help (decision trees, message sequences, topic hierarchies). Preview of what a rendered diagram looks like on this theme:


<img width="812" height="756" alt="mermaid-example" src="https://github.com/user-attachments/assets/0108ae29-1289-4543-9f42-5c8641384adf" />
