### PR TITLE
Enable copy button, search suggestions and anchor tracking

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,8 +18,12 @@ theme:
     - navigation.top
     # - navigation.expand
     - navigation.instant
+    - navigation.tracking
     - navigation.tabs
     - content.action.edit
+    - content.code.copy
+    - search.suggest
+    - search.highlight
     # - toc.integrate
   palette:
     - scheme: slate


### PR DESCRIPTION
﻿Four small Material theme features, all client-side and zero-maintenance:

- `content.code.copy` adds the copy-to-clipboard button to code blocks; the JSON API and compiling pages benefit most.
- `search.suggest` shows completion hints while typing in the search box, and `search.highlight` highlights the search terms on the page you land on.
- `navigation.tracking` keeps the URL in sync with the active section anchor while scrolling, so links people copy from the address bar point at the section they were reading.

No content changes; pages render identically apart from the new copy button.
