### PR TITLE
Modernize the deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: Auto-Build Documentation using MkDocs
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Build and deploy the documentation on every push to the main branch
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -25,6 +25,4 @@ jobs:
           pip install mkdocs-material
 
       - name: Deploy
-        run: |
-          git pull
-          mkdocs gh-deploy
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
﻿- `actions/checkout@v2` and `setup-python@v2` run on a deprecated Node runtime that GitHub has scheduled for removal; once it's shut off, merges to main will stop deploying the site. Bumped to v4/v5.
- Dropped the `git pull` before deploy: the checkout is already at the pushed commit, and pulling mid-job is a leftover race workaround.
- `mkdocs gh-deploy --force`, the documented way to overwrite the gh-pages branch history.
- Added `workflow_dispatch` so a deploy can be re-run manually from the Actions tab when needed.
- Fixed the stale "master branch" comment.

Deliberately unchanged: the unpinned `pip install mkdocs-material`, matching current behavior. Pinning it for reproducible deploys would be a separate discussion.
