### PR TITLE
Replace hand-made Moved stub pages with real redirects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs-material
+          pip install mkdocs-material mkdocs-redirects
 
       - name: Deploy
         run: mkdocs gh-deploy --force

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
 
 **Python/pip:**
 ```bash
-pip install mkdocs-material
+pip install mkdocs-material mkdocs-redirects
 mkdocs serve
 ```
 

--- a/docs/advanced/compile-analog.md
+++ b/docs/advanced/compile-analog.md
@@ -1,8 +1,0 @@
----
-title: Compile Analog WLED
-hide:
-  # - navigation
-  # - toc
----
-
-Moved, see [How to compile WLED](/advanced/compiling-wled.md)

--- a/docs/advanced/compile-wled.md
+++ b/docs/advanced/compile-wled.md
@@ -1,8 +1,0 @@
----
-title: Compile WLED
-hide:
-  # - navigation
-  # - toc
----
-
-Moved, see [How to compile WLED](/advanced/compiling-wled)

--- a/docs/basics/compiling-wled.md
+++ b/docs/basics/compiling-wled.md
@@ -1,8 +1,0 @@
----
-title: Compiling WLED
-hide:
-  # - navigation
-  # - toc
----
-
-Moved, see [How to compile WLED](/advanced/compiling-wled)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,8 +33,13 @@ theme:
       toggle: 
         icon: material/weather-night
         name: Dark Mode
-plugins: 
+plugins:
   - search
+  - redirects:
+      redirect_maps:
+        advanced/compile-analog.md: advanced/compiling-wled.md
+        advanced/compile-wled.md: advanced/compiling-wled.md
+        basics/compiling-wled.md: advanced/compiling-wled.md
 markdown_extensions:
   - admonition
   - attr_list


### PR DESCRIPTION
﻿Three pages contain only a "Moved, see..." line that readers have to click through manually: `advanced/compile-analog`, `advanced/compile-wled`, and `basics/compiling-wled`. This replaces them with the mkdocs-redirects plugin: the old URLs now serve an instant redirect with a canonical link to [Compiling WLED](https://kno.wled.ge/advanced/compiling-wled/), so old bookmarks and inbound links keep working and search engines index the right page.

The plugin is added to the deploy workflow and to the AGENTS.md pip preview instructions. The Docker preview path needs no change: the `squidfunk/mkdocs-material` image already bundles mkdocs-redirects via the `mkdocs-material[recommended]` extra.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Consolidated compiling documentation under a single updated page.
  - Added redirects from older compilation documentation links so existing bookmarks continue to work.
  - Removed outdated placeholder pages that pointed to relocated content.

- **Bug Fixes**
  - Documentation builds and local previews now support redirect handling, ensuring moved pages resolve correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->