### PR TITLE
Reworked the WLED ESP Flasher page and added mkdocs content tab support

### DIFF
--- a/docs/basics/install-wled-flasher.md
+++ b/docs/basics/install-wled-flasher.md
@@ -1,5 +1,5 @@
 ---
-title: Installation using ESP GUI
+title: Install using WLED ESP Flasher
 hide:
   # - navigation
   # - toc
@@ -12,11 +12,21 @@ You can find precompiled .bin files on the [official release page](https://bin.w
 If you are not sure what binary you should use look at this page:
 [What binary should I use?](/basics/install-binary#what-binary-should-i-use)
 
-## 2. Downloading the ESP WLED Flasher
+## 2. Downloading the WLED ESP Flasher
 
-You can find and download flasher [here](https://github.com/srg74/WLED-wemos-shield/tree/master/resources/Firmware/WLED_%20ESP_Flasher)!
+The flasher is maintained in the [WLED-wemos-shield project](https://github.com/srg74/WLED-wemos-shield). Download it for your operating system:
 
-After downloading a file, unzip it and start
+=== "Windows"
+
+    [Download WLED ESP Flasher for Windows](https://github.com/srg74/WLED-wemos-shield/raw/master/resources/Firmware/WLED_%20ESP_Flasher/Windows.zip)
+
+    Unzip the file and start the flasher.
+
+=== "macOS"
+
+    [Download WLED ESP Flasher for macOS](https://github.com/srg74/WLED-wemos-shield/raw/master/resources/Firmware/WLED_%20ESP_Flasher/macOS.zip)
+
+    Unzip the file and start the flasher.
 
 ## 3. Flashing firmware bin files
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,9 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.tabbed:
       alternate_style: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
   - pymdownx.tilde
 extra:
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,8 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.tilde
 extra:
   social:
@@ -88,6 +90,7 @@ nav:
     - Installation:
       - Install WLED Binary: basics/install-binary.md
       - Install using ESP GUI: basics/install-gui.md
+      - Install using WLED ESP Flasher: basics/install-wled-flasher.md
       - Compiling WLED: advanced/compiling-wled.md
     - Tutorials: basics/tutorials.md
     - FAQ: basics/faq.md


### PR DESCRIPTION
﻿The WLED ESP Flasher page was orphaned: absent from the nav, and its front-matter title duplicated the ESP GUI page ("Installation using ESP GUI") even though it documents a different tool (the flasher from the [WLED-wemos-shield project](https://github.com/srg74/WLED-wemos-shield)). The Install Binary page actively recommends it for ESP32, so it deserves a sidebar entry.

- Retitle to "Install using WLED ESP Flasher" and register it under Basics > Installation, resolving the title collision.
- Replace the browse-the-GitHub-folder download step with Windows/macOS content tabs that link the zips directly (both verified working).
- Enable `pymdownx.tabbed` (alternate style), Material's content tabs. This is the first page to use them; other OS- or board-split pages like Install Binary could adopt them later.

Demo:

<img width="1452" height="672" alt="install-wled-flasher-content-tabs-example" src="https://github.com/user-attachments/assets/4ee2a727-4a5f-4693-bac7-116ada3d29de" />


---

Update: added a slugify function to the tabbed config so tab anchors derive from the labels (`#windows` / `#macos`) instead of the auto-generated `#__tabbed_1_1` ids, which makes shared links to a specific tab readable and stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance with clearer, step-by-step instructions for downloading and launching WLED ESP Flasher on Windows and macOS.
  * Renamed the installation page to “Install using WLED ESP Flasher.”
  * Added the installation guide to the documentation navigation.
  * Enabled tabbed content formatting for improved documentation usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->